### PR TITLE
in do.sh's install_deps, remove git clone that's no longer needed

### DIFF
--- a/do.sh
+++ b/do.sh
@@ -21,7 +21,6 @@ PYTHON_CMD="python"
 JSCOMPILE_CMD="$PYTHON_CMD lib/closure-library/closure/bin/build/closurebuilder.py -c lib/closure-compiler/compiler.jar"
 BUILD_DIR="build"
 BUILD_TPL_DIR="$BUILD_DIR/templates"
-SRC_REPO_URL="https://code.google.com/p/end-to-end/"
 cd ${0%/*}
 
 e2e_assert_dependencies() {
@@ -143,9 +142,6 @@ e2e_build_clean() {
 e2e_install_deps() {
   echo "Installing build dependencies..."
   ./download-libs.sh
-  if [ ! -d src/.git ]; then
-    git clone "$SRC_REPO_URL" src/
-  fi
   echo "Done."
 }
 


### PR DESCRIPTION
in do.sh's install_deps, remove git clone that's no longer needed in the github world and just outputs an error:

```
$ ./do.sh install_deps
....
Archive:  closure-templates-for-javascript-latest.zip
  inflating: closure-templates-compiler/COPYING  
  inflating: closure-templates-compiler/README  
  inflating: closure-templates-compiler/SoyToJsSrcCompiler.jar  
  inflating: closure-templates-compiler/soyutils.js  
  inflating: closure-templates-compiler/soyutils_usegoog.js  
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 2188k  100 2188k    0     0  2271k      0 --:--:-- --:--:-- --:--:-- 2270k
fatal: destination path 'src' already exists and is not an empty directory.
Done.
```
