### PR TITLE
Removed Closure Templates dependency.

### DIFF
--- a/README.build
+++ b/README.build
@@ -23,7 +23,6 @@ Google End-To-End. Building End-To-End should be fairly easy on any Linux/OSX sy
 To build End-To-End, the following requirements must be met:
  - bash
  - git
- - svn
  - curl
  - unzip
  - Java 1.7

--- a/do.sh
+++ b/do.sh
@@ -35,7 +35,7 @@ e2e_assert_dependencies() {
   # Check if required files are present.
   files=( lib/closure-library/closure/bin/build/closurebuilder.py \
     lib/closure-library \
-    lib/closure-templates \
+    lib/closure-templates-compiler \
     lib/typedarray \
     lib/zlib.js \
     lib/closure-stylesheets-20111230.jar \
@@ -77,7 +77,7 @@ e2e_build_library() {
   BUILD_EXT_DIR="$BUILD_DIR/library"
   echo "Building End-To-End library into $BUILD_EXT_DIR ..."
   mkdir -p "$BUILD_EXT_DIR"
-  SRC_DIRS=( src lib/closure-library lib/closure-templates/javascript $BUILD_TPL_DIR \
+  SRC_DIRS=( src lib/closure-library lib/closure-templates-compiler $BUILD_TPL_DIR \
     lib/zlib.js/src lib/typedarray )
   # See https://developers.google.com/closure/library/docs/closurebuilder
   jscompile_e2e="$JSCOMPILE_CMD"
@@ -99,7 +99,7 @@ e2e_build_extension() {
   mkdir -p "$BUILD_EXT_DIR"
   echo "Building End-To-End extension to $BUILD_EXT_DIR"
   SRC_EXT_DIR="src/javascript/crypto/e2e/extension"
-  SRC_DIRS=( src lib/closure-library lib/closure-templates/javascript $BUILD_TPL_DIR \
+  SRC_DIRS=( src lib/closure-library lib/closure-templates-compiler $BUILD_TPL_DIR \
     lib/zlib.js/src lib/typedarray )
 
   # See https://developers.google.com/closure/library/docs/closurebuilder
@@ -150,13 +150,13 @@ e2e_install_deps() {
 }
 
 e2e_testserver() {
-  e2e_build_templates 
+  e2e_build_templates
   echo "Generating build/test_js_deps-runfiles.js file..."
   mkdir -p "$BUILD_DIR"
   $PYTHON_CMD lib/closure-library/closure/bin/build/depswriter.py \
     --root_with_prefix="build/templates/ ../../../build/templates/" \
     --root_with_prefix="src/javascript/crypto/e2e/ ../crypto/e2e/" \
-    --root_with_prefix="lib/closure-templates/javascript/ ../../../../lib/closure-templates/javascript" \
+    --root_with_prefix="lib/closure-templates-compiler/ ../../../../lib/closure-templates-compiler" \
     --root_with_prefix="lib/zlib.js/ ../../../lib/zlib.js/" \
     > "$BUILD_DIR/test_js_deps-runfiles.js"
 

--- a/download-libs.sh
+++ b/download-libs.sh
@@ -28,11 +28,6 @@ if [ ! -d closure-library/.git ]; then
   git clone --depth 1 https://github.com/google/closure-library/ closure-library
 fi
 
-# checkout closure templates
-if [ ! -d closure-templates/.svn ]; then
-  svn checkout https://closure-templates.googlecode.com/svn/trunk/ closure-templates
-fi
-
 # checkout zlib.js
 if [ ! -d zlib.js/.git ]; then
   git clone --depth 1 https://github.com/imaya/zlib.js zlib.js


### PR DESCRIPTION
Now we depend only on the Closure Templates Compiler binary - this fixes version mismatch that broke some of the tests and the extension.
