### PR TITLE
PROMPT: Support optional subject field in encryptsign panel

### DIFF
--- a/src/javascript/crypto/e2e/extension/_locales/en/messages.json
+++ b/src/javascript/crypto/e2e/extension/_locales/en/messages.json
@@ -271,6 +271,10 @@
     "message": "From:",
     "description": "The label to describe who is the author of the message."
   },
+  "promptSubjectLabel": {
+    "message": "Subject:",
+    "description": "The label to describe the subject of the message."
+  },
   "promptNoPrivateKeysFound": {
     "message": "Generate or import private key(s) to sign or decrypt messages",
     "description": "The label to inform the user that he needs a private key to use signing/decryption functionality"

--- a/src/javascript/crypto/e2e/extension/constants.js
+++ b/src/javascript/crypto/e2e/extension/constants.js
@@ -83,6 +83,7 @@ e2e.ext.constants.ElementId = {
   CHIP_HOLDER: 'chipHolder',
   PASSPHRASE_ENCRYPTION_LINK: 'passphraseEncryptionLink',
   FROM_HOLDER: 'fromHolder',
+  SUBJECT_HOLDER: 'subjectHolder',
 
   /* Used to display menus in the UI. */
   MENU_CONTAINER: 'menu-container',

--- a/src/javascript/crypto/e2e/extension/launcher.js
+++ b/src/javascript/crypto/e2e/extension/launcher.js
@@ -81,17 +81,20 @@ ext.Launcher = function() {
  *     if this is the final update to the selected content.
  * @param {!function(...)} callback The function to invoke once the content has
  *     been updated.
+ * @param {string=} opt_subject The subject of the message if applicable.
  * @expose
  */
 ext.Launcher.prototype.updateSelectedContent =
-    function(content, recipients, origin, expectMoreUpdates, callback) {
+    function(content, recipients, origin, expectMoreUpdates,
+             callback, opt_subject) {
   this.getActiveTab_(goog.bind(function(tabId) {
     chrome.tabs.sendMessage(tabId, {
       value: content,
       response: true,
       detach: !Boolean(expectMoreUpdates),
       origin: origin,
-      recipients: recipients
+      recipients: recipients,
+      subject: opt_subject
     });
     callback();
   }, this));

--- a/src/javascript/crypto/e2e/extension/messages.js
+++ b/src/javascript/crypto/e2e/extension/messages.js
@@ -38,6 +38,7 @@ var messages = e2e.ext.messages;
  *   action: (e2e.ext.constants.Actions|undefined),
  *   request: boolean,
  *   origin: string,
+ *   subject: (string|undefined),
  *   canInject: boolean
  * }}
  */
@@ -52,6 +53,7 @@ messages.BridgeMessageRequest;
  *   response: boolean,
  *   detach: boolean,
  *   origin: string,
+ *   subject: (string|undefined),
  *   recipients: !Array.<string>
  * }}
  */

--- a/src/javascript/crypto/e2e/extension/ui/panels/prompt/encryptsign_test.js
+++ b/src/javascript/crypto/e2e/extension/ui/panels/prompt/encryptsign_test.js
@@ -259,6 +259,7 @@ function testSaveDraftIntoPage() {
   var origin = 'http://www.example.com';
   var plaintext = 'plaintext message';
   var encrypted = 'header\n\nencrypted message';
+  var subject = 'some subject';
 
   var encryptCb = new goog.testing.mockmatchers.SaveArgument(goog.isFunction);
   stubs.setPath('e2e.ext.actions.EncryptSign.prototype.execute',
@@ -283,20 +284,26 @@ function testSaveDraftIntoPage() {
   stubs.set(e2e.ext.utils.action, 'updateSelectedContent',
       mockControl.createFunctionMock('updateSelectedContent'));
   var contentArg = new goog.testing.mockmatchers.SaveArgument(goog.isString);
+  var subjectArg = new goog.testing.mockmatchers.SaveArgument(function(a) {
+    return (!goog.isDef(a) || goog.isString(a));
+  });
   e2e.ext.utils.action.updateSelectedContent(contentArg, [], origin, true,
       goog.testing.mockmatchers.ignoreArgument,
-      goog.testing.mockmatchers.ignoreArgument);
+      goog.testing.mockmatchers.ignoreArgument, subjectArg);
 
   mockControl.$replayAll();
   panel.setContentInternal({
     request: true,
     selection: plaintext,
     recipients: [USER_ID],
-    origin: origin
+    origin: origin,
+    subject: subject
   });
   panel.render(document.body);
   textArea = document.querySelector('textarea');
   assertEquals(plaintext, textArea.value);
+  subjectInput = document.getElementById(constants.ElementId.SUBJECT_HOLDER);
+  assertEquals(subject, subjectInput.value);
 
   panel.saveDraft_(origin, {type: 'click'});
   encryptCb.arg(encrypted);

--- a/src/javascript/crypto/e2e/extension/ui/panels/prompt/prompt.soy
+++ b/src/javascript/crypto/e2e/extension/ui/panels/prompt/prompt.soy
@@ -38,6 +38,8 @@
  * @param saveDraftButtonTitle The title of the save button.
  * @param insertButtonTitle The title of the insert button.
  * @param cancelButtonTitle The title of the cancel button.
+ * @param subject The value of the subject field if applicable.
+ * @param subjectLabel The label to describe the "Subject:" box if applicable.
  */
 {template .renderEncrypt}
   <div id="{e2e.ext.constants.ElementId.FROM_HOLDER}">
@@ -47,6 +49,12 @@
   <div id="{e2e.ext.constants.ElementId.CHIP_HOLDER}"></div>
   <div id="{e2e.ext.constants.ElementId.PASSPHRASE_ENCRYPTION_LINK}">
     + {$passphraseEncryptionLinkTitle}
+  </div>
+  <div>
+    {if isNonnull($subject)}
+      <input id="{e2e.ext.constants.ElementId.SUBJECT_HOLDER}" type="text"
+        placeholder={$subjectLabel} value="{$subject}" />
+    {/if}
   </div>
   <textarea></textarea>
   <div>

--- a/src/javascript/crypto/e2e/extension/ui/prompt/prompt.js
+++ b/src/javascript/crypto/e2e/extension/ui/prompt/prompt.js
@@ -173,6 +173,7 @@ ui.Prompt.prototype.processSelectedContent_ =
     recipients = contentBlob.recipients || [];
     contentBlob.action = action;
     canInject = contentBlob.canInject;
+    contentBlob.subject = contentBlob.subject || undefined;
   }
 
   if (!this.pgpLauncher_.hasPassphrase() &&

--- a/src/javascript/crypto/e2e/extension/ui/prompt/prompt_test.js
+++ b/src/javascript/crypto/e2e/extension/ui/prompt/prompt_test.js
@@ -372,6 +372,7 @@ function testDecrypt() {
 function testContentInsertedOnEncrypt() {
   var plaintext = 'irrelevant';
   var origin = 'http://www.example.com';
+  var subject = 'encrypted message';
 
   stubs.replace(e2e.ext.utils.text, 'extractValidEmail',
       function(recipient) {
@@ -383,8 +384,11 @@ function testContentInsertedOnEncrypt() {
   stubs.set(prompt.pgpLauncher_, 'updateSelectedContent',
       mockControl.createFunctionMock('updateSelectedContent'));
   var encryptedMsg = new goog.testing.mockmatchers.SaveArgument(goog.isString);
+  var subjectMsg = new goog.testing.mockmatchers.SaveArgument(function(a) {
+    return (!goog.isDef(a) || goog.isString(a));
+  });
   prompt.pgpLauncher_.updateSelectedContent(encryptedMsg, [USER_ID], origin,
-      false, goog.testing.mockmatchers.ignoreArgument);
+      false, goog.testing.mockmatchers.ignoreArgument, subjectMsg);
 
   mockControl.$replayAll();
   populatePgpKeys();
@@ -397,7 +401,8 @@ function testContentInsertedOnEncrypt() {
       selection: plaintext,
       recipients: [USER_ID],
       origin: origin,
-      canInject: true
+      canInject: true,
+      subject: subject
     }, constants.Actions.ENCRYPT_SIGN);
 
     var protectBtn = document.querySelector('button.action');
@@ -409,6 +414,7 @@ function testContentInsertedOnEncrypt() {
       insertBtn.click();
 
       assertContains('-----BEGIN PGP MESSAGE-----', encryptedMsg.arg);
+      assertEquals(subject, subjectMsg.arg);
       mockControl.$verifyAll();
       asyncTestCase.continueTesting();
     }, 500);

--- a/src/javascript/crypto/e2e/extension/utils/action.js
+++ b/src/javascript/crypto/e2e/extension/utils/action.js
@@ -118,16 +118,17 @@ utils.getSelectedContent = function(callback, errorCallback, opt_scope) {
  *     been updated.
  * @param {!function(Error)} errorCallback The callback to invoke if an error is
  *     encountered.
+ * @param {string=} opt_subject The subject of the message if applicable.
  * @param {T=} opt_scope Optional. The scope in which the function and the
  *     callbacks will be called.
  * @template T
  */
 utils.updateSelectedContent = function(content, recipients, origin,
-    expectMoreUpdates, callback, errorCallback, opt_scope) {
+    expectMoreUpdates, callback, errorCallback, opt_subject, opt_scope) {
   var scope = opt_scope || goog.global;
   utils.getExtensionLauncher(function(launcher) {
     launcher.updateSelectedContent(content, recipients, origin,
-        expectMoreUpdates, goog.bind(callback, scope));
+        expectMoreUpdates, goog.bind(callback, scope), opt_subject);
   }, errorCallback, opt_scope);
 };
 

--- a/src/javascript/crypto/e2e/extension/utils/action_test.js
+++ b/src/javascript/crypto/e2e/extension/utils/action_test.js
@@ -120,6 +120,7 @@ function testUpdateSelectedContent() {
   var content = 'irrelevant';
   var recipients = [];
   var origin = 'irrelevant';
+  var subject = 'irrelevant';
   var expectMoreUpdates = false;
   var callback = mockControl.createFunctionMock();
   callback();
@@ -128,11 +129,12 @@ function testUpdateSelectedContent() {
   stubs.set(
       launcher, 'updateSelectedContent', mockControl.createFunctionMock());
   launcher.updateSelectedContent(
-      content, recipients, origin, expectMoreUpdates, callbackArg);
+      content, recipients, origin, expectMoreUpdates, callbackArg, subject);
 
   mockControl.$replayAll();
   utils.updateSelectedContent(
-      content, recipients, origin, expectMoreUpdates, callback);
+      content, recipients, origin, expectMoreUpdates, callback,
+      goog.nullFunction, subject);
   callbackArg.arg();
   mockControl.$verifyAll();
 }


### PR DESCRIPTION
The Yahoo version of the extension content script supports changing the subject field of a message in the prompt. Right now this is just for usability but it could also be used to make sure the user doesn't accidentally leak info in the subject line (ex: autofill the subject field in the prompt with "Encrypted Message" and show a warning to the user when they change it).
