### PR TITLE
Add utility methods for checking gmail/ymail origins

### DIFF
--- a/src/javascript/crypto/e2e/extension/helper/helper.js
+++ b/src/javascript/crypto/e2e/extension/helper/helper.js
@@ -374,7 +374,7 @@ ext.Helper.prototype.enableLookingGlass_ = function() {
  * @private
  */
 ext.Helper.prototype.isGmail_ = function() {
-  return this.getOrigin_() == 'https://mail.google.com';
+  return utils.text.isGmailOrigin(this.getOrigin_());
 };
 
 

--- a/src/javascript/crypto/e2e/extension/ui/glass/bootstrap.js
+++ b/src/javascript/crypto/e2e/extension/ui/glass/bootstrap.js
@@ -19,23 +19,14 @@
  */
 
 goog.require('e2e.ext.ui.Glass');
+goog.require('e2e.ext.utils.text');
 goog.require('goog.crypt.base64');
 
 goog.provide('e2e.ext.ui.glass.bootstrap');
 
-
-/**
- * The list of origins that can use the looking glass.
- * @type {!Array.<string>}
- * @const
- */
-var LOOKING_GLASS_WHITELIST = [
-  'https://mail.google.com'
-];
-
 // Create the looking glass.
 window.addEventListener('message', function(evt) {
-  if (LOOKING_GLASS_WHITELIST.indexOf(evt.origin) == -1) {
+  if (!e2e.ext.utils.text.isGmailOrigin(evt.origin)) {
     return;
   }
 

--- a/src/javascript/crypto/e2e/extension/utils/text.js
+++ b/src/javascript/crypto/e2e/extension/utils/text.js
@@ -22,6 +22,7 @@ goog.provide('e2e.ext.utils.text');
 
 goog.require('e2e.ext.constants');
 goog.require('e2e.ext.constants.Actions');
+goog.require('goog.Uri');
 goog.require('goog.array');
 goog.require('goog.format.EmailAddress');
 goog.require('goog.string');
@@ -116,4 +117,27 @@ utils.extractValidEmail = function(recipient) {
   return email;
 };
 
-});  // goog.scope
+
+/**
+ * Checks whether a URI is an HTTPS ymail origin.
+ * @param {!string} uri
+ * @return {boolean}
+ */
+utils.isYmailOrigin = function(uri) {
+  uri = new goog.Uri(uri);
+  return (uri.getScheme() === 'https'
+          && goog.string.endsWith(uri.getDomain(), '.mail.yahoo.com'));
+};
+
+
+/**
+ * Checks whether a URI is an HTTPS Gmail origin.
+ * @param {!string} uri
+ * @return {boolean}
+ */
+utils.isGmailOrigin = function(uri) {
+  uri = new goog.Uri(uri);
+  return (uri.getScheme() === 'https' &&
+          uri.getDomain() === 'mail.google.com');
+};
+}); // goog.scope

--- a/src/javascript/crypto/e2e/extension/utils/text_test.js
+++ b/src/javascript/crypto/e2e/extension/utils/text_test.js
@@ -23,6 +23,7 @@ goog.provide('e2e.ext.utils.textTest');
 
 goog.require('e2e.ext.constants.Actions');
 goog.require('e2e.ext.utils.text');
+goog.require('goog.array');
 goog.require('goog.testing.asserts');
 goog.require('goog.testing.jsunit');
 goog.setTestOnly();
@@ -81,4 +82,33 @@ function testExtractValidEmail() {
       utils.extractValidEmail('"inv\"<alid <invalid@example.com>'));
   assertEquals(null,
       utils.extractValidEmail('fails#e2e.regexp.vali@dation.com'));
+}
+
+
+function testIsGmailOrigin() {
+  var gmailOrigins = ['https://mail.google.com/foo', 'https://mail.google.com',
+    'https://mail.google.com:443/foo#bar'];
+  var nonGmailOrigins = ['http://mail.google.com', 'https://mail.yahoo.com',
+    'https://mail.google.com.evil.com', 'https://foo.mail.google.com'];
+  goog.array.forEach(gmailOrigins, function(uri) {
+    assertTrue(utils.isGmailOrigin(uri));
+  });
+  goog.array.forEach(nonGmailOrigins, function(uri) {
+    assertFalse(utils.isGmailOrigin(uri));
+  });
+}
+
+
+function testIsYmailOrigin() {
+  var ymailOrigins = ['https://example.mail.yahoo.com/foo',
+    'https://us-mg5.mail.yahoo.com', 'https://www.us-mg5.mail.yahoo.com/foo',
+    'https://us-mg999.mail.yahoo.com:443/foo#bar'];
+  var nonYmailOrigins = ['http://mail.google.com', 'http://www.mail.yahoo.com',
+    'https://www.mail.yahoo.com.evil.com', 'https://mail.yahoo.com'];
+  goog.array.forEach(ymailOrigins, function(uri) {
+    assertTrue(utils.isYmailOrigin(uri));
+  });
+  goog.array.forEach(nonYmailOrigins, function(uri) {
+    assertFalse(utils.isYmailOrigin(uri));
+  });
 }


### PR DESCRIPTION
Yahoo Mail pages are located at *.mail.yahoo.com, so exact string comparison doesn't work for them. The new methods will also work on full URI strings, not just origins.

This is part of the big Yahoo code merge that is being split into small pull requests. (Is there a way to create a meta-bug to track these on Github?)
