### PR TITLE
More strict build settings.

### DIFF
--- a/compiler.flags
+++ b/compiler.flags
@@ -1,0 +1,33 @@
+--language_in=ECMASCRIPT5
+--jscomp_error=accessControls
+--jscomp_error=ambiguousFunctionDecl
+--jscomp_error=checkDebuggerStatement
+--jscomp_error=checkEventfulObjectDisposal
+--jscomp_error=checkRegExp
+--jscomp_error=checkTypes
+--jscomp_error=checkVars
+--jscomp_error=const
+--jscomp_error=constantProperty
+--jscomp_error=deprecated
+--jscomp_error=duplicate
+--jscomp_error=duplicateMessage
+--jscomp_error=es5Strict
+--jscomp_error=es3
+--jscomp_error=externsValidation
+--jscomp_error=fileoverviewTags
+--jscomp_error=globalThis
+--jscomp_error=internetExplorerChecks
+--jscomp_error=invalidCasts
+--jscomp_error=missingProperties
+--jscomp_error=nonStandardJsDocs
+--jscomp_error=strictModuleDepCheck
+--jscomp_error=undefinedNames
+--jscomp_error=undefinedVars
+--jscomp_error=unknownDefines
+--jscomp_error=uselessCode
+--jscomp_error=visibility
+--externs=lib/chrome_extensions.js
+--only_closure_dependencies
+--manage_closure_dependencies
+--js lib/closure-library/closure/goog/deps.js
+--js build/deps.js

--- a/download-libs.sh
+++ b/download-libs.sh
@@ -54,4 +54,15 @@ if [ ! -f closure-stylesheets-20111230.jar ]; then
   curl https://closure-stylesheets.googlecode.com/files/closure-stylesheets-20111230.jar -O
 fi
 
+if [ ! -f chrome_extensions.js ]; then
+  curl https://raw.githubusercontent.com/google/closure-compiler/master/contrib/externs/chrome_extensions.js -O
+fi
+
+# Temporary fix
+# Soy file bundled with the compiler does not compile with strict settings:
+# lib/closure-templates-compiler/soyutils_usegoog.js:1762: ERROR - element JS_STR_CHARS does not exist on this enum
+cd closure-templates-compiler
+curl https://raw.githubusercontent.com/google/closure-templates/master/javascript/soyutils_usegoog.js -O
+cd ..
+
 cd ..

--- a/src/javascript/crypto/e2e/compression/zip.js
+++ b/src/javascript/crypto/e2e/compression/zip.js
@@ -46,7 +46,7 @@ goog.inherits(e2e.compression.Zip,
 
 /** @inheritDoc */
 e2e.compression.Zip.prototype.decompress = function(compressedData) {
-  var data = (new Zlib.RawInflate(compressedData)).decompress();
+  var data = (new Zlib.RawInflate(compressedData, null)).decompress();
   data = goog.array.clone(data);
   return e2e.async.Result.toResult(data);
 };

--- a/src/javascript/crypto/e2e/e2e.js
+++ b/src/javascript/crypto/e2e/e2e.js
@@ -33,14 +33,14 @@ goog.require('goog.crypt');
 
 /**
  * DwordArray is an array of 32 bits long big endian numbers.
- * @typedef {Array.<number>}
+ * @typedef {!Array.<number>}
  */
 e2e.DwordArray;
 
 
 /**
  * ByteArray is an array of 8 bits long numbers.
- * @typedef {Array.<number>}
+ * @typedef {!Array.<number>}
  */
 e2e.ByteArray;
 

--- a/src/javascript/crypto/e2e/extension/actions/decryptverify.js
+++ b/src/javascript/crypto/e2e/extension/actions/decryptverify.js
@@ -22,6 +22,7 @@
 goog.provide('e2e.ext.actions.DecryptVerify');
 
 goog.require('e2e');
+goog.require('e2e.ext.actions.Action');
 goog.require('e2e.ext.utils');
 goog.require('e2e.ext.utils.Error');
 goog.require('e2e.ext.utils.action');
@@ -35,7 +36,7 @@ var utils = e2e.ext.utils;
 /**
  * Constructor for the action.
  * @constructor
- * @implements {actions.Action.<string, string>}
+ * @implements {e2e.ext.actions.Action.<string, string>}
  */
 actions.DecryptVerify = function() {};
 

--- a/src/javascript/crypto/e2e/extension/actions/encryptsign.js
+++ b/src/javascript/crypto/e2e/extension/actions/encryptsign.js
@@ -21,6 +21,7 @@
 
 goog.provide('e2e.ext.actions.EncryptSign');
 
+goog.require('e2e.ext.actions.Action');
 goog.require('e2e.ext.utils.Error');
 goog.require('goog.array');
 goog.require('goog.string');
@@ -34,7 +35,7 @@ var utils = e2e.ext.utils;
 /**
  * Constructor for the action.
  * @constructor
- * @implements {actions.Action.<string, string>}
+ * @implements {e2e.ext.actions.Action.<string, string>}
  */
 actions.EncryptSign = function() {};
 

--- a/src/javascript/crypto/e2e/extension/actions/getkeydescription.js
+++ b/src/javascript/crypto/e2e/extension/actions/getkeydescription.js
@@ -20,6 +20,7 @@
 
 goog.provide('e2e.ext.actions.GetKeyDescription');
 
+goog.require('e2e.ext.actions.Action');
 goog.require('e2e.ext.constants.ElementId');
 goog.require('e2e.ext.ui.dialogs.ImportConfirmation');
 goog.require('e2e.ext.utils.Error');
@@ -36,7 +37,7 @@ var utils = e2e.ext.utils;
 /**
  * Constructor for the action.
  * @constructor
- * @implements {actions.Action.<string, (string|undefined)>}
+ * @implements {e2e.ext.actions.Action.<string, (string|undefined)>}
  */
 actions.GetKeyDescription = function() {};
 

--- a/src/javascript/crypto/e2e/extension/actions/getkeyringbackupdata.js
+++ b/src/javascript/crypto/e2e/extension/actions/getkeyringbackupdata.js
@@ -20,6 +20,8 @@
 
 goog.provide('e2e.ext.actions.GetKeyringBackupData');
 
+goog.require('e2e.ext.actions.Action');
+
 
 goog.scope(function() {
 var actions = e2e.ext.actions;
@@ -29,7 +31,8 @@ var actions = e2e.ext.actions;
 /**
  * Constructor for the action.
  * @constructor
- * @implements {actions.Action.<undefined, e2e.openpgp.KeyringBackupInfo>}
+ * @implements {e2e.ext.actions.Action.<undefined,
+ *     e2e.openpgp.KeyringBackupInfo>}
  */
 actions.GetKeyringBackupData = function() {};
 

--- a/src/javascript/crypto/e2e/extension/actions/importkey.js
+++ b/src/javascript/crypto/e2e/extension/actions/importkey.js
@@ -20,6 +20,7 @@
 
 goog.provide('e2e.ext.actions.ImportKey');
 
+goog.require('e2e.ext.actions.Action');
 goog.require('e2e.ext.actions.GetKeyDescription');
 goog.require('e2e.ext.constants.ElementId');
 goog.require('e2e.ext.utils.Error');
@@ -36,7 +37,7 @@ var utils = e2e.ext.utils;
 /**
  * Constructor for the action.
  * @constructor
- * @implements {actions.Action.<string, !Array.<string>>}
+ * @implements {e2e.ext.actions.Action.<string, !Array.<string>>}
  */
 actions.ImportKey = function() {};
 

--- a/src/javascript/crypto/e2e/extension/actions/listkeys.js
+++ b/src/javascript/crypto/e2e/extension/actions/listkeys.js
@@ -20,6 +20,7 @@
 
 goog.provide('e2e.ext.actions.ListKeys');
 
+goog.require('e2e.ext.actions.Action');
 goog.require('e2e.ext.utils.Error');
 goog.require('goog.object');
 
@@ -32,7 +33,7 @@ var utils = e2e.ext.utils;
 /**
  * Constructor for the action.
  * @constructor
- * @implements {actions.Action.<string, !e2e.openpgp.KeyRingMap>}
+ * @implements {e2e.ext.actions.Action.<string, !e2e.openpgp.KeyRingMap>}
  */
 actions.ListKeys = function() {};
 

--- a/src/javascript/crypto/e2e/extension/actions/restorekeyringdata.js
+++ b/src/javascript/crypto/e2e/extension/actions/restorekeyringdata.js
@@ -21,6 +21,7 @@
 goog.provide('e2e.ext.actions.RestoreKeyringData');
 
 goog.require('e2e.error.InvalidArgumentsError');
+goog.require('e2e.ext.actions.Action');
 goog.require('e2e.openpgp.KeyRing');
 goog.require('goog.crypt.base64');
 
@@ -32,7 +33,7 @@ var actions = e2e.ext.actions;
 /**
  * Constructor for the action.
  * @constructor
- * @implements {actions.Action.<{data: string, email: string}, string>}
+ * @implements {e2e.ext.actions.Action.<{data: string, email: string}, string>}
  */
 actions.RestoreKeyringData = function() {};
 

--- a/src/javascript/crypto/e2e/extension/helper/helper.js
+++ b/src/javascript/crypto/e2e/extension/helper/helper.js
@@ -147,8 +147,8 @@ ext.Helper.prototype.isEditable_ = function(elem) {
 /**
  * Sets the value into the active element.
  * @param {Element} elem The element where the value must be set.
- * @param {messages.BridgeMessageResponse} msg The response bridge message from
- *     the extension.
+ * @param {e2e.ext.messages.BridgeMessageResponse} msg The response bridge
+ *     message from the extension.
  * @private
  */
 ext.Helper.prototype.setValue_ = function(elem, msg) {
@@ -165,8 +165,8 @@ ext.Helper.prototype.setValue_ = function(elem, msg) {
 
 /**
  * Sets the recipients and message body into a Gmail compose window via gmonkey.
- * @param {messages.BridgeMessageResponse} msg The response bridge message from
- *     the extension.
+ * @param {e2e.ext.messages.BridgeMessageResponse} msg The response bridge
+ *     message from the extension.
  * @private
  */
 ext.Helper.prototype.setGmonkeyValue_ = function(msg) {
@@ -201,8 +201,8 @@ ext.Helper.prototype.runOnce = function() {
 
 /**
  * Retrieves OpenPGP content selected by the user using native browser API.
- * @param {!messages.GetSelectionRequest} selectionRequest The request to get
- *     the user-selected content.
+ * @param {!e2e.ext.messages.GetSelectionRequest} selectionRequest The request
+ *     to get the user-selected content.
  * @param {function(*)} callback A callback to pass the selected content to.
  * @private
  */
@@ -229,8 +229,8 @@ ext.Helper.prototype.getSelectedContentNative_ = function(selectionRequest,
 
 /**
  * Retrieves OpenPGP content selected by the user using GMonkey API.
- * @param {!messages.GetSelectionRequest} selectionRequest The request to get
- *     the user-selected content.
+ * @param {!e2e.ext.messages.GetSelectionRequest} selectionRequest The request
+ *     to get the user-selected content.
  * @param {function(*)} callback A callback to pass the selected content to.
  * @private
  */
@@ -307,7 +307,8 @@ ext.Helper.prototype.getSelectedContent_ = function(req, sender, callback) {
     this.executed_ = true;
   }
 
-  var selectionRequest = /** @type {!messages.GetSelectionRequest} */ (req);
+  var selectionRequest = /** @type {!e2e.ext.messages.GetSelectionRequest} */ (
+      req);
 
   if (!Boolean(this.getSelection_()) && this.isGmail_()) {
     gmonkey.isAvailable(goog.bind(function(isAvailable) {

--- a/src/javascript/crypto/e2e/extension/utils/text.js
+++ b/src/javascript/crypto/e2e/extension/utils/text.js
@@ -124,9 +124,9 @@ utils.extractValidEmail = function(recipient) {
  * @return {boolean}
  */
 utils.isYmailOrigin = function(uri) {
-  uri = new goog.Uri(uri);
-  return (uri.getScheme() === 'https' &&
-      goog.string.endsWith(uri.getDomain(), '.mail.yahoo.com'));
+  var googUri = new goog.Uri(uri);
+  return (googUri.getScheme() === 'https' &&
+      goog.string.endsWith(googUri.getDomain(), '.mail.yahoo.com'));
 };
 
 
@@ -136,8 +136,8 @@ utils.isYmailOrigin = function(uri) {
  * @return {boolean}
  */
 utils.isGmailOrigin = function(uri) {
-  uri = new goog.Uri(uri);
-  return (uri.getScheme() === 'https' &&
-          uri.getDomain() === 'mail.google.com');
+  var googUri = new goog.Uri(uri);
+  return (googUri.getScheme() === 'https' &&
+          googUri.getDomain() === 'mail.google.com');
 };
 });  // goog.scope


### PR DESCRIPTION
- Removed closurebuilder.py dependency (it's deprecated and does not calculate dependencies correctly).
  Unfortunately this means now cannot build truly 'debug' builds with all the comments.
- Build script output is now cleaner
- Added compiler.flags file to hold all future command line parameters for Closure Compiler
- As a temporary measure, using soyutils_usegoog.js straight from GitHub
  (the one bundled with compiled Soy Compiler fails to build)
- Fixed all build errors due to new stricter settings
