### PR TITLE
Support PGP interactions on Yahoo mail

### DIFF
--- a/src/javascript/crypto/e2e/extension/actions/executor.js
+++ b/src/javascript/crypto/e2e/extension/actions/executor.js
@@ -25,6 +25,7 @@ goog.require('e2e.ext.actions.EncryptSign');
 goog.require('e2e.ext.actions.GetKeyDescription');
 goog.require('e2e.ext.actions.GetKeyringBackupData');
 goog.require('e2e.ext.actions.ImportKey');
+goog.require('e2e.ext.actions.ListAllUids');
 goog.require('e2e.ext.actions.ListKeys');
 goog.require('e2e.ext.actions.RestoreKeyringData');
 goog.require('e2e.ext.constants.Actions');
@@ -106,6 +107,8 @@ actions.Executor.prototype.getAction_ = function(actionType) {
       return new actions.GetKeyringBackupData();
     case constants.Actions.IMPORT_KEY:
       return new actions.ImportKey();
+    case constants.Actions.LIST_ALL_UIDS:
+      return new actions.ListAllUids();
     case constants.Actions.LIST_KEYS:
       return new actions.ListKeys();
     case constants.Actions.RESTORE_KEYRING_DATA:

--- a/src/javascript/crypto/e2e/extension/actions/listalluids.js
+++ b/src/javascript/crypto/e2e/extension/actions/listalluids.js
@@ -1,0 +1,59 @@
+/**
+ * @license
+ * Copyright 2014 Google Inc. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Lists all public or private keys (never both) in the extension.
+ */
+
+goog.provide('e2e.ext.actions.ListAllUids');
+
+goog.require('e2e.ext.actions.Action');
+goog.require('goog.array');
+
+goog.scope(function() {
+var actions = e2e.ext.actions;
+var utils = e2e.ext.utils;
+
+
+
+/**
+ * Constructor for the action.
+ * @constructor
+ * @implements {e2e.ext.actions.Action.<string, !Array>}
+ */
+actions.ListAllUids = function() {};
+
+
+/** @inheritDoc */
+actions.ListAllUids.prototype.execute =
+    function(ctx, request, requestor, callback, errorCallback) {
+  ctx.getAllKeys(request.content === 'private').
+      addCallback(function(result) {
+        var uids = [];
+        for (var keyId in result) {
+          var keys = result[keyId];
+          goog.array.forEach(keys, function(key) {
+            if (key && key.uids) {
+              goog.array.extend(uids, key.uids);
+            }
+          });
+        }
+        callback(uids);
+      }).
+      addErrback(errorCallback);
+};
+
+});  // goog.scope

--- a/src/javascript/crypto/e2e/extension/actions/listalluids_test.html
+++ b/src/javascript/crypto/e2e/extension/actions/listalluids_test.html
@@ -1,0 +1,25 @@
+<!-- Copyright 2014 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -->
+<!DOCTYPE html>
+<html>
+<head>
+<title>Unit Test of e2e.ext.actions.ListAllUids</title>
+<script src="../../../../../../javascript/closure/base.js"></script>
+<script src="test_js_deps-runfiles.js"></script>
+<script>
+  goog.require('e2e.ext.actions.ListAllUidsTest');
+</script>
+</head>
+</html>

--- a/src/javascript/crypto/e2e/extension/api/api.js
+++ b/src/javascript/crypto/e2e/extension/api/api.js
@@ -132,6 +132,8 @@ api.Api.prototype.executeAction_ = function(callback, req) {
   switch (incoming.action) {
     case constants.Actions.ENCRYPT_SIGN:
     case constants.Actions.DECRYPT_VERIFY:
+    case constants.Actions.LIST_ALL_UIDS:
+    case constants.Actions.GET_KEYRING_UNLOCKED:
       break;
     default:
       outgoing.error = chrome.i18n.getMessage('errorUnsupportedAction');
@@ -139,10 +141,16 @@ api.Api.prototype.executeAction_ = function(callback, req) {
       return;
   }
 
-  if (window.launcher && !window.launcher.hasPassphrase()) {
+  var hasPassphrase = window.launcher ? window.launcher.hasPassphrase() : false;
+
+  if (!hasPassphrase) {
     callback({
       error: chrome.i18n.getMessage('glassKeyringLockedError')
     });
+    return;
+  } else if (incoming.action === constants.Actions.GET_KEYRING_UNLOCKED) {
+    outgoing.content = true;
+    callback(outgoing);
     return;
   }
 

--- a/src/javascript/crypto/e2e/extension/constants.js
+++ b/src/javascript/crypto/e2e/extension/constants.js
@@ -24,6 +24,8 @@ goog.provide('e2e.ext.constants.BackupCode');
 goog.provide('e2e.ext.constants.CssClass');
 goog.provide('e2e.ext.constants.ElementId');
 goog.provide('e2e.ext.constants.StorageKey');
+goog.provide('e2e.ext.constants.e2ebind.requestActions');
+goog.provide('e2e.ext.constants.e2ebind.responseActions');
 
 
 /**
@@ -46,6 +48,8 @@ e2e.ext.constants.Actions = {
   RESTORE_KEYRING_DATA: 'restore_keyring_data',
   IMPORT_KEY: 'import_key',
   LIST_KEYS: 'list_keys',
+  LIST_ALL_UIDS: 'list_all_uids',
+  GET_KEYRING_UNLOCKED: 'get_keyring_unlocked',
 
   // Intended no-op. Used for closing the prompt UI when other visual elements
   // (e.g. looking glass) would display data.
@@ -99,7 +103,10 @@ e2e.ext.constants.ElementId = {
   WELCOME_FOOTER: 'welcome-footer',
 
   // Chrome notifications
-  NOTIFICATION_SUCCESS: 'e2e-success'
+  NOTIFICATION_SUCCESS: 'e2e-success',
+
+  // e2ebind page elements
+  E2EBIND_ICON: 'endtoend'
 };
 
 
@@ -224,3 +231,29 @@ e2e.ext.constants.BackupCode = {
  * @const
  */
 e2e.ext.constants.BACKUP_CODE_LENGTH = 24;
+
+
+/**
+ * e2ebind API response actions.
+ * @const
+ */
+e2e.ext.constants.e2ebind.responseActions = {
+  HAS_DRAFT: 'has_draft',
+  GET_DRAFT: 'get_draft',
+  SET_DRAFT: 'set_draft',
+  GET_CURRENT_MESSAGE: 'get_current_message'
+};
+
+
+/**
+ * e2ebind API request actions.
+ * @const
+ */
+e2e.ext.constants.e2ebind.requestActions = {
+  START: 'start',
+  INSTALL_READ_GLASS: 'install_read_glass',
+  INSTALL_COMPOSE_GLASS: 'install_compose_glass',
+  VALIDATE_SIGNER: 'validate_signer',
+  VALIDATE_RECIPIENTS: 'validate_recipients',
+  SET_SIGNER: 'set_signer'
+};

--- a/src/javascript/crypto/e2e/extension/helper/e2ebind.js
+++ b/src/javascript/crypto/e2e/extension/helper/e2ebind.js
@@ -1,0 +1,606 @@
+/**
+ * @license
+ * Copyright 2014 Yahoo Inc. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Provides a wrapper around the E2E bind API for interacting
+ *   with Yahoo Mail.
+ * @author jonathanpierce@outlook.com (Jonathan Pierce)
+ * @author yzhu@yahoo-inc.com (Yan Zhu)
+ */
+
+goog.provide('e2e.ext.e2ebind');
+
+goog.require('e2e.ext.constants.Actions');
+goog.require('e2e.ext.constants.ElementId');
+goog.require('e2e.ext.constants.e2ebind.requestActions');
+goog.require('e2e.ext.constants.e2ebind.responseActions');
+goog.require('e2e.ext.ui.GlassWrapper');
+goog.require('e2e.ext.utils.text');
+goog.require('e2e.openpgp.asciiArmor');
+goog.require('goog.Uri');
+goog.require('goog.array');
+goog.require('goog.dom');
+goog.require('goog.events');
+goog.require('goog.events.EventType');
+goog.require('goog.string');
+
+
+goog.scope(function() {
+var e2ebind = e2e.ext.e2ebind;
+var ext = e2e.ext;
+var constants = ext.constants;
+var messages = ext.messages;
+var utils = e2e.ext.utils;
+var ui = ext.ui;
+
+
+/**
+ * True if e2ebind has been started.
+ * @type {boolean}
+ * @private
+ */
+e2ebind.started_ = false;
+
+
+/**
+ * Checks if e2ebind has been started.
+ * @return {boolean}
+ */
+e2ebind.isStarted = function() {
+  return e2ebind.started_;
+};
+
+
+
+/**
+* Hash table for associating unique IDs with request/response pairs
+* @constructor
+* @private
+*/
+e2ebind.MessagingTable_ = function() {
+  this.table = {};
+};
+
+
+/**
+ * Generates a short, non-cryptographically random string.
+ * @return {string}
+ */
+e2ebind.MessagingTable_.prototype.getRandomString = function() {
+  return goog.string.getRandomString();
+};
+
+
+/**
+ * Adds an entry to the hash table.
+ * @param {string} action The action associated with the entry.
+ * @param {function(messages.e2ebindResponse)=} opt_callback The callback
+ *   associated with the entry.
+ * @return {string} The hash value.
+ */
+e2ebind.MessagingTable_.prototype.add = function(action, opt_callback) {
+  var hash = this.getRandomString();
+  while (this.table[hash]) {
+    // Ensure unqiueness.
+    hash = this.getRandomString();
+  }
+  this.table[hash] = {
+    action: action,
+    callback: opt_callback
+  };
+  return hash;
+};
+
+
+/**
+* Retrieves the callback associated with a hash value and an action.
+* @param {string} hash
+* @param {string} action
+* @return {{action:string,callback:(function(*)|undefined)}}
+*/
+e2ebind.MessagingTable_.prototype.get = function(hash, action) {
+  var result = null;
+  if (this.table[hash] && this.table[hash].action === action) {
+    result = this.table[hash];
+  }
+  this.table[hash] = null;
+  return result;
+};
+
+
+/**
+ * onmessage event listener.
+ * @param {!Object} response The message sent from the page via
+ *   window.postMessage.
+ * @private
+ */
+e2ebind.messageHandler_ = function(response) {
+  try {
+    var data = /** @type {messages.e2ebindRequest} */
+        (window.JSON.parse(response.data));
+    if (response.source !== window.self ||
+        response.origin !== window.location.origin ||
+        data.api !== 'e2ebind' || data.source === 'E2E') {
+      return;
+    }
+
+    if (data.action.toUpperCase() in constants.e2ebind.requestActions) {
+      e2ebind.handleProviderRequest_(data);
+    } else if (
+        data.action.toUpperCase() in constants.e2ebind.responseActions) {
+      e2ebind.handleProviderResponse_(data);
+    }
+  } catch (e) {
+    return;
+  }
+};
+
+
+/**
+ * Custom click event handler for e2ebind page elements.
+ * @param {Element} e The element that was clicked.
+ * @private
+ */
+e2ebind.clickHandler_ = function(e) {
+  var elt = e.target;
+
+  if (elt.id === constants.ElementId.E2EBIND_ICON) {
+    e2ebind.sendExtensionRequest_({
+      action: constants.Actions.GET_KEYRING_UNLOCKED
+    }, goog.bind(function(response) {
+      if (response.error || !response.content) {
+        // Can't install compose glass if the keyring is locked
+        window.alert(chrome.i18n.getMessage('glassKeyringLockedError'));
+      } else {
+        // Get the compose window associated with the clicked icon
+        var composeElem = goog.dom.getAncestorByTagNameAndClass(elt,
+                                                                'div',
+                                                                'compose');
+        var draft = {};
+        draft.from = window.config.signer ? '<' + window.config.signer + '>' :
+            '';
+
+        e2ebind.hasDraft(goog.bind(function(hasDraftResult) {
+          if (hasDraftResult) {
+            e2ebind.getDraft(goog.bind(function(getDraftResult) {
+              draft.body = e2e.openpgp.asciiArmor.
+                  extractPgpBlock(getDraftResult.body);
+              draft.to = getDraftResult.to;
+              draft.cc = getDraftResult.cc;
+              draft.bcc = getDraftResult.bcc;
+              draft.subject = getDraftResult.subject;
+              // Compose glass implementation will be in a future patch.
+              //e2ebind.installComposeGlass_(composeElem, draft);
+            }, this));
+          } else {
+            e2ebind.getCurrentMessage(goog.bind(function(result) {
+              var DOMelem = document.querySelector(result.elem);
+              if (result.text) {
+                draft.body = result.text;
+              } else if (DOMelem) {
+                draft.body = e2e.openpgp.asciiArmor.extractPgpBlock(
+                    goog.isDef(DOMelem.lookingGlass) ?
+                    DOMelem.lookingGlass.getOriginalContent() :
+                    DOMelem.innerText);
+              }
+              //e2ebind.installComposeGlass_(composeElem, draft);
+            }, this));
+          }
+        }, this));
+      }
+    }, this));
+  }
+};
+
+
+/**
+* Start listening for responses and requests to/from the provider.
+*/
+e2ebind.start = function() {
+  var uri = new goog.Uri(window.location.href);
+  // Use the version of YMail that has the endtoend module included.
+  if (utils.text.isYmailOrigin(window.location.href) &&
+      !uri.getParameterValue('endtoend')) {
+    uri.setParameterValue('endtoend', 1);
+    uri.setParameterValue('composev3', 0);
+    window.location.href = uri.toString();
+    return;
+  }
+
+  e2ebind.messagingTable = new e2ebind.MessagingTable_();
+
+  goog.events.listen(window, goog.events.EventType.CLICK,
+                     e2ebind.clickHandler_, true);
+  window.addEventListener('message', goog.bind(e2ebind.messageHandler_, this));
+};
+
+
+/**
+ * Stops the e2ebind API
+ * @private
+ */
+e2ebind.stop_ = function() {
+  window.removeEventListener('message', goog.bind(e2ebind.messageHandler_,
+                                                  this));
+  e2ebind.messagingTable = undefined;
+  e2ebind.started_ = false;
+  window.config = {};
+  window.valid = undefined;
+  goog.events.unlisten(window, goog.events.EventType.CLICK,
+                       e2ebind.clickHandler_);
+};
+
+
+/**
+* Sends a request to the provider.
+* @param {string} action The action requested.
+* @param {Object} args The arguments to the action.
+* @param {function(messages.e2ebindResponse)=} opt_callback The function to
+*   callback with the response
+*/
+e2ebind.sendRequest = function(action, args, opt_callback) {
+  if (!e2ebind.messagingTable) {
+    return;
+  }
+
+  var hash = e2ebind.messagingTable.add(action, opt_callback);
+
+  var reqObj = /** @type {messages.e2ebindRequest} */ ({
+    api: 'e2ebind',
+    source: 'E2E',
+    action: action,
+    args: args,
+    hash: hash
+  });
+
+  window.postMessage(window.JSON.stringify(reqObj), window.location.origin);
+};
+
+
+/**
+* Sends a response to a request from a provider
+* @param {Object} result The result field of the response message
+* @param {messages.e2ebindRequest} request The request we are responding to
+* @param {boolean} success Whether or not the request was successful.
+* @private
+*/
+e2ebind.sendResponse_ = function(result, request, success) {
+  var returnObj = /** @type {messages.e2ebindResponse} */ ({
+    api: 'e2ebind',
+    result: result,
+    success: success,
+    action: request.action,
+    hash: request.hash,
+    source: 'E2E'
+  });
+
+  window.postMessage(window.JSON.stringify(returnObj), window.location.origin);
+};
+
+
+/**
+* Handles a response to a request we sent
+* @param {messages.e2ebindResponse} response The provider's response to a
+*   request we sent.
+* @private
+*/
+e2ebind.handleProviderResponse_ = function(response) {
+  if (!e2ebind.messagingTable) {
+    return;
+  }
+
+  var request = e2ebind.messagingTable.get(response.hash, response.action);
+
+  if (!request) {
+    return;
+  }
+
+  if (request.callback) {
+    request.callback(response);
+  }
+};
+
+
+/**
+* Handle an incoming request from the provider.
+* @param {messages.e2ebindRequest} request The request from the provider.
+* @private
+*/
+e2ebind.handleProviderRequest_ = function(request) {
+  var actions = constants.e2ebind.requestActions;
+
+  if (request.action !== actions.START && !e2ebind.started_) {
+    return;
+  }
+
+  var args = request.args;
+
+  switch (request.action) {
+    case actions.START:
+      (function() {
+        if (!e2ebind.started_) {
+          // Note that we've attempted to start, and set the config
+          e2ebind.started_ = true;
+          window.config = {
+            signer: String(args.signer),
+            version: String(args.version),
+            read_glass_enabled: Boolean(args.read_glass_enabled),
+            compose_glass_enabled: Boolean(args.compose_glass_enabled)
+          };
+
+          // Verify the signer
+          e2ebind.validateSigner_(String(args.signer), function(valid) {
+            window.valid = valid;
+            e2ebind.sendResponse_({valid: valid}, request, true);
+          });
+        } else {
+          // We've already started.
+          e2ebind.sendResponse_(null, request, false);
+        }
+      })();
+
+      break;
+
+    case actions.INSTALL_READ_GLASS:
+      (function() {
+        if (window.config.read_glass_enabled && args.messages && window.valid) {
+          try {
+            goog.array.forEach(args.messages, function(message) {
+              // XXX: message.elem is a selector string, not a DOM element
+              var DOMelem = document.querySelector(message.elem);
+              e2ebind.installReadGlass_(DOMelem, message.text);
+            });
+            e2ebind.sendResponse_(null, request, true);
+          } catch (ex) {
+            e2ebind.sendResponse_(null, request, false);
+          }
+        }
+      })();
+
+      break;
+
+    case actions.INSTALL_COMPOSE_GLASS:
+      // TODO: Support compose glass in YMail
+      break;
+
+    case actions.SET_SIGNER:
+      (function() {
+        // validates and updates the signer/validity in E2E
+        if (!args.signer) {
+          return;
+        }
+        window.config.signer = String(args.signer);
+        try {
+          e2ebind.validateSigner_(String(args.signer), function(valid) {
+            window.valid = valid;
+            e2ebind.sendResponse_({valid: valid}, request, true);
+          });
+        } catch (ex) {
+          e2ebind.sendResponse_(null, request, false);
+        }
+      })();
+
+      break;
+
+    case actions.VALIDATE_SIGNER:
+      (function() {
+        try {
+          if (!args.signer) {
+            return;
+          }
+          e2ebind.validateSigner_(String(args.signer), function(valid) {
+            e2ebind.sendResponse_({valid: valid}, request, true);
+          });
+        } catch (ex) {
+          e2ebind.sendResponse_(null, request, false);
+        }
+      })();
+
+      break;
+
+    case actions.VALIDATE_RECIPIENTS:
+      (function() {
+        try {
+          if (!args.recipients || !(args.recipients instanceof Array) ||
+              !window.valid) {
+            return;
+          }
+          e2ebind.validateRecipients_(args.recipients, function(results) {
+            e2ebind.sendResponse_({results: results}, request, true);
+          });
+        } catch (ex) {
+          e2ebind.sendResponse_(null, request, false);
+        }
+      })();
+
+      break;
+  }
+};
+
+
+/**
+* Installs a read looking glass in the page.
+* @param {Element} elem  element to install the glass in
+* @param {string=} opt_text Optional alternative text to elem's innerText
+* @private
+*/
+e2ebind.installReadGlass_ = function(elem, opt_text) {
+  var DOMelem = elem;
+
+  if (!DOMelem) {
+    throw 'Element not found.';
+  }
+
+  if (Boolean(DOMelem.lookingGlass)) {
+    return;
+  }
+
+  var selectionBody = e2e.openpgp.asciiArmor.extractPgpBlock(
+      opt_text ? opt_text : DOMelem.innerText);
+  var action = utils.text.getPgpAction(selectionBody, true);
+
+  if (action == constants.Actions.DECRYPT_VERIFY) {
+    var glassWrapper = new ui.GlassWrapper(DOMelem, opt_text);
+    window.helper.registerDisposable(glassWrapper);
+    glassWrapper.installGlass();
+  }
+};
+
+
+/**
+* Gets the currently selected message, if any, from the provider
+* @param {!function(Object)} callback The callback to call with the result
+*/
+e2ebind.getCurrentMessage = function(callback) {
+  e2ebind.sendRequest(constants.e2ebind.responseActions.GET_CURRENT_MESSAGE,
+                      null, function(data) {
+        var elem;
+        var text;
+
+        if (data.result && data.success) {
+          var result = data.result;
+          elem = result.elem;
+          text = result.text;
+        }
+
+        callback({elem: elem, text: text});
+      });
+};
+
+
+/**
+* Gets the current draft/compose from the provider.
+* @param {!function(Object)} callback - The callback to call with the result
+*/
+e2ebind.getDraft = function(callback) {
+  e2ebind.sendRequest(constants.e2ebind.responseActions.GET_DRAFT, null,
+                      function(data) {
+        var result = null;
+
+        if (data.success) {
+          result = data.result;
+        }
+
+        callback(result);
+      });
+};
+
+
+/**
+ * Indicates if there is an active draft in the provider.
+ * @param {!function(boolean)} callback The callback where the active draft
+ *     information should be passed.
+ */
+e2ebind.hasDraft = function(callback) {
+  e2ebind.sendRequest(constants.e2ebind.responseActions.HAS_DRAFT, null,
+                      function(data) {
+        var result = false;
+
+        if (data.success && data.result.has_draft) {
+          result = true;
+        }
+
+        callback(result);
+      });
+};
+
+
+/**
+* Sets the currently active draft/compose in the provider
+* @param {Object} args The data to set the draft with.
+*/
+e2ebind.setDraft = function(args) {
+  // TODO(yan): Doesn't work when multiple provider compose windows are open
+  // on the same page
+  e2ebind.sendRequest('set_draft', /** @type {messages.e2ebindDraft} */ ({
+    to: args.to || [],
+    cc: args.cc || [],
+    bcc: args.bcc || [],
+    subject: args.subject || '',
+    body: args.body || ''
+  }));
+};
+
+
+/**
+* Validates whather or not we have a private key for this signer.
+* @param {string} signer The signer ("name@domain.com") we wish to validate
+* @param {!function(boolean)} callback Callback to call with the result.
+* @private
+*/
+e2ebind.validateSigner_ = function(signer, callback) {
+  e2ebind.sendExtensionRequest_({
+    action: constants.Actions.LIST_ALL_UIDS,
+    content: 'private'
+  }, function(response) {
+    response.content = response.content || [];
+    var emails = utils.text.getValidEmailAddressesFromArray(response.content,
+                                                            true);
+    var valid = goog.array.contains(emails, signer);
+    callback(valid);
+  });
+};
+
+
+/**
+* Validates whether we have a public key for these recipients.
+* @param {Array.<string>} recipients The recipients we are checking
+* @param {!function(!Array)} callback Callback to call with the result.
+* @private
+*/
+e2ebind.validateRecipients_ = function(recipients, callback) {
+  e2ebind.sendExtensionRequest_({
+    action: constants.Actions.LIST_ALL_UIDS,
+    content: 'public'
+  }, function(response) {
+    response.content = response.content || [];
+    var emails = utils.text.getValidEmailAddressesFromArray(response.content,
+                                                            true);
+    var results = [];
+    goog.array.forEach(recipients, function(recipient) {
+      var valid = goog.array.contains(emails, recipient);
+      results.push({valid: valid, recipient: recipient});
+    });
+    callback(results);
+  });
+};
+
+
+/**
+* Sends a request to the launcher to perform some action.
+* @param {Object} args The message we wish to send to the launcher,
+*   should heve an 'action' property.
+* @param {!function(messages.e2ebindResponse)} callback Callback to call with
+*   the result.
+* @private
+*/
+e2ebind.sendExtensionRequest_ = function(args, callback) {
+  var port = chrome.runtime.connect();
+  port.postMessage(args);
+
+  var respHandler = function(response) {
+    if (callback) {
+      callback(response);
+    }
+    port.disconnect();
+  };
+  port.onMessage.addListener(respHandler);
+  port.onDisconnect.addListener(function() {
+    port = null;
+  });
+};
+
+});  // goog.scope

--- a/src/javascript/crypto/e2e/extension/helper/e2ebind.js
+++ b/src/javascript/crypto/e2e/extension/helper/e2ebind.js
@@ -92,11 +92,11 @@ e2ebind.MessagingTable_.prototype.getRandomString = function() {
  * @return {string} The hash value.
  */
 e2ebind.MessagingTable_.prototype.add = function(action, opt_callback) {
-  var hash = this.getRandomString();
-  while (this.table[hash]) {
-    // Ensure unqiueness.
+  var hash;
+  do {
+    // Ensure uniqueness.
     hash = this.getRandomString();
-  }
+  } while (this.table.hasOwnProperty(hash) && this.table[hash] !== null);
   this.table[hash] = {
     action: action,
     callback: opt_callback
@@ -113,7 +113,9 @@ e2ebind.MessagingTable_.prototype.add = function(action, opt_callback) {
 */
 e2ebind.MessagingTable_.prototype.get = function(hash, action) {
   var result = null;
-  if (this.table[hash] && this.table[hash].action === action) {
+  if (this.table.hasOwnProperty(hash) &&
+      this.table[hash] !== null &&
+      this.table[hash].action === action) {
     result = this.table[hash];
   }
   this.table[hash] = null;

--- a/src/javascript/crypto/e2e/extension/helper/e2ebind_test.html
+++ b/src/javascript/crypto/e2e/extension/helper/e2ebind_test.html
@@ -1,0 +1,25 @@
+<!-- Copyright 2013 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -->
+<!DOCTYPE html>
+<html>
+<head>
+<title>Unit Test of e2e.ext.e2ebind</title>
+<script src="../../../../../../javascript/closure/base.js"></script>
+<script src="test_js_deps-runfiles.js"></script>
+<script>
+  goog.require('e2e.ext.e2ebindTest');
+</script>
+</head>
+</html>

--- a/src/javascript/crypto/e2e/extension/helper/e2ebind_test.js
+++ b/src/javascript/crypto/e2e/extension/helper/e2ebind_test.js
@@ -1,0 +1,437 @@
+/**
+ * @license
+ * Copyright 2014 Yahoo Inc. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Tests for the wrapper of the e2ebind API.
+ */
+
+/** @suppress {extraProvide} */
+goog.provide('e2e.ext.e2ebindTest');
+
+goog.require('e2e.ext.Helper');
+goog.require('e2e.ext.constants');
+goog.require('e2e.ext.constants.e2ebind.requestActions');
+goog.require('e2e.ext.e2ebind');
+goog.require('goog.asserts');
+goog.require('goog.testing.AsyncTestCase');
+goog.require('goog.testing.MockControl');
+goog.require('goog.testing.PropertyReplacer');
+goog.require('goog.testing.asserts');
+goog.require('goog.testing.jsunit');
+goog.require('goog.testing.mockmatchers');
+goog.require('goog.testing.mockmatchers.ArgumentMatcher');
+goog.require('goog.testing.mockmatchers.SaveArgument');
+
+goog.setTestOnly();
+
+var actions = e2e.ext.constants.e2ebind.requestActions;
+var api = null;
+var asyncTestCase = goog.testing.AsyncTestCase.createAndInstall(document.title);
+var constants = e2e.ext.constants;
+var draft = null;
+var e2ebind = e2e.ext.e2ebind;
+var stubs = new goog.testing.PropertyReplacer();
+var RECIPIENTS = ['test@example.com' , 't2@example.com', 'cc@example.com'];
+var mockControl = null;
+var providerRequestHandler = goog.nullFunction;
+
+
+function setUp() {
+  window.config = {};
+  mockControl = new goog.testing.MockControl();
+
+  stubs.setPath('chrome.runtime.getURL', function(filename) {
+    return './' + filename;
+  });
+  document.documentElement.id = 'test_id';
+
+  // Simulate the provider listener
+  window.addEventListener('message', function(msg) {
+    var data = window.JSON.parse(msg.data);
+    if (msg.source === window.self &&
+        data.api === 'e2ebind' &&
+        data.source === 'E2E') {
+      data.source = 'provider';
+      data = providerRequestHandler(data);
+      window.postMessage(JSON.stringify(data), window.location.origin);
+    }
+  });
+
+  draft = {
+    to: 'test@example.com, "we <ird>>\'>, <a@a.com>, n<ess" <t2@example.com>' +
+        ', "inv\"<alid <invalid@example.com>, fails#e2e.regexp.vali@dation.com',
+    cc: 'cc@example.com',
+    bcc: 'bcc@example.com',
+    body: 'some text<br>with new<br>lines',
+    from: 'yan@example.com',
+    subject: 'encrypted msg'
+  };
+}
+
+
+function tearDown() {
+  stubs.reset();
+  e2ebind.stop_();
+  window.helper = null;
+  window.onmessage = null;
+}
+
+
+function testStart() {
+  assertEquals(undefined, e2ebind.messagingTable);
+  e2ebind.start();
+  goog.asserts.assertInstanceof(e2ebind.messagingTable,
+                                e2ebind.MessagingTable_);
+}
+
+
+function testMessagingTableAddAndGet() {
+  var mt = new e2ebind.MessagingTable_();
+  var action = 'irrelevant';
+  var hash = mt.add(action, goog.nullFunction);
+  var entry = mt.get(hash, action);
+  assertEquals(entry.action, action);
+  assertEquals(entry.callback, goog.nullFunction);
+}
+
+
+function testIsStarted() {
+  assertFalse(e2ebind.isStarted());
+  e2ebind.started_ = true;
+  assertTrue(e2ebind.isStarted());
+}
+
+
+function testE2ebindIconClick() {
+  var clickHandled = false;
+
+  stubs.replace(e2ebind, 'sendExtensionRequest_', function(request, cb) {
+    if (request.action === constants.Actions.GET_KEYRING_UNLOCKED) {
+      cb({content: true, completedAction: request.action});
+    }
+  });
+  stubs.replace(e2ebind, 'hasDraft', function() {
+    clickHandled = true;
+  });
+
+  e2ebind.start();
+
+  var icon = document.createElement('div');
+  icon.id = constants.ElementId.E2EBIND_ICON;
+  document.body.appendChild(icon);
+  icon.click();
+
+  asyncTestCase.waitForAsync('Waiting for e2ebind icon click handler.');
+  window.setTimeout(function() {
+    assertTrue(clickHandled);
+    asyncTestCase.continueTesting();
+  }, 500);
+}
+
+
+function testSendRequest() {
+  var action = 'irrelevant';
+
+  providerRequestHandler = function(data) {
+    return data;
+  };
+
+  stubs.set(e2ebind, 'messageHandler_', function(response) {
+    var data = window.JSON.parse(response.data);
+
+    if (data.source === 'E2E') { return; }
+
+    assertEquals(window.self, response.source);
+    assertEquals('e2ebind', data.api);
+    assertEquals('provider', data.source);
+
+    e2ebind.handleProviderResponse_(data);
+  });
+
+
+  e2ebind.start();
+
+  asyncTestCase.waitForAsync('Waiting for request to be sent by e2ebind');
+  e2ebind.sendRequest(action, null, function(response) {
+    asyncTestCase.continueTesting();
+  });
+}
+
+
+function testProviderRequestToStart() {
+  var signer = 'irrelevant';
+  stubs.replace(e2ebind, 'validateSigner_', mockControl.createFunctionMock());
+
+  var validateSignerArg = new goog.testing.mockmatchers.ArgumentMatcher(
+      function(arg) {
+        assertEquals(signer, arg);
+        return true;
+      });
+  var callbackArg = new goog.testing.mockmatchers.SaveArgument(goog.isFunction);
+
+  e2ebind.validateSigner_(validateSignerArg, callbackArg);
+
+  mockControl.$replayAll();
+
+  e2ebind.handleProviderRequest_({
+    action: actions.START,
+    args: {signer: signer, version: 0, read_glass_enabled: true}
+  });
+
+  assertTrue(e2ebind.started_);
+  assertEquals(window.config.signer, signer);
+  assertEquals(window.config.version, '0');
+  assertTrue(window.config.read_glass_enabled);
+  assertFalse(window.config.compose_glass_enabled);
+
+  mockControl.$verifyAll();
+}
+
+
+function testProviderRequestToInstallReadGlass() {
+  window.config.read_glass_enabled = true;
+  window.valid = true;
+  e2ebind.started_ = true;
+  window.helper = new e2e.ext.Helper();
+
+  var s1 = '#s1';
+  var s2 = '#s2';
+  var div1 = document.createElement('div');
+  var div2 = document.createElement('div');
+  div1.id = 's1';
+  div2.id = 's2';
+  var text1 = '-----BEGIN PGP MESSAGE-----';
+  var text2 = 'foo';
+  document.body.appendChild(div1);
+  document.body.appendChild(div2);
+
+  stubs.replace(e2ebind, 'sendResponse_', mockControl.createFunctionMock());
+  var successArg = new goog.testing.mockmatchers.ArgumentMatcher(
+      function(arg) {
+        assertTrue(arg);
+        return true;
+      });
+  var requestArg = new goog.testing.mockmatchers.ArgumentMatcher(
+      function(arg) {
+        assertEquals(actions.INSTALL_READ_GLASS, arg.action);
+        return true;
+      });
+  e2ebind.sendResponse_(goog.testing.mockmatchers.ignoreArgument,
+                        requestArg, successArg);
+
+  mockControl.$replayAll();
+
+  e2ebind.handleProviderRequest_({
+    action: actions.INSTALL_READ_GLASS,
+    args: {messages: [{elem: s1, text: text1}, {elem: s2, text: text2}]}
+  });
+
+  assertEquals(div1.lookingGlass.originalText_, text1);
+  assertEquals(div2.lookingGlass, undefined);
+  div1.lookingGlass.disposeInternal();
+  mockControl.$verifyAll();
+}
+
+
+function testProviderRequestToSetSigner() {
+  var signer = 'yzhu@yahoo-inc.com';
+  e2ebind.started_ = true;
+
+  stubs.replace(e2ebind, 'validateSigner_', function(s, cb) {
+    cb(s === signer);
+  });
+
+  stubs.replace(e2ebind, 'sendResponse_', mockControl.createFunctionMock());
+  var successArg = new goog.testing.mockmatchers.ArgumentMatcher(
+      function(arg) {
+        assertTrue(arg);
+        return true;
+      });
+  var validityArg = new goog.testing.mockmatchers.ArgumentMatcher(
+      function(arg) {
+        assertTrue(arg.valid);
+        return true;
+      });
+  e2ebind.sendResponse_(validityArg, goog.testing.mockmatchers.ignoreArgument,
+                        successArg);
+  mockControl.$replayAll();
+
+  e2ebind.handleProviderRequest_({
+    action: actions.SET_SIGNER,
+    args: {signer: signer}
+  });
+
+  assertEquals(signer, window.config.signer);
+  assertTrue(window.valid);
+  mockControl.$verifyAll();
+}
+
+
+function testProviderRequestToValidateSigner() {
+  var signer = 'yzhu@yahoo-inc.com';
+  e2ebind.started_ = true;
+
+  stubs.replace(e2ebind, 'sendExtensionRequest_', function(request, cb) {
+    var response = {};
+    response.completedAction = request.action;
+    if (request.action === constants.Actions.LIST_ALL_UIDS &&
+        request.content === 'private') {
+      response.content = ['yzhu@yahoo-inc.com', 'yan@example.com'];
+    }
+    cb(response);
+  });
+  stubs.replace(e2ebind, 'sendResponse_', mockControl.createFunctionMock());
+  var successArg = new goog.testing.mockmatchers.ArgumentMatcher(
+      function(arg) {
+        assertTrue(arg);
+        return true;
+      });
+  var validityArg = new goog.testing.mockmatchers.ArgumentMatcher(
+      function(arg) {
+        assertTrue(arg.valid);
+        return true;
+      });
+  e2ebind.sendResponse_(validityArg, goog.testing.mockmatchers.ignoreArgument,
+                        successArg);
+  mockControl.$replayAll();
+
+  e2ebind.handleProviderRequest_({
+    action: actions.VALIDATE_SIGNER,
+    args: {signer: signer}
+  });
+  mockControl.$verifyAll();
+}
+
+
+function testProviderRequestToValidateRecipients() {
+  e2ebind.started_ = true;
+  window.valid = true;
+
+  stubs.replace(e2ebind, 'sendExtensionRequest_', function(request, cb) {
+    var response = {};
+    response.completedAction = request.action;
+    if (request.action === constants.Actions.LIST_ALL_UIDS &&
+        request.content === 'public') {
+      response.content = ['yzhu@yahoo-inc.com', 'yan@example.com',
+        'cc@example.com'];
+    }
+    cb(response);
+  });
+  stubs.replace(e2ebind, 'sendResponse_', mockControl.createFunctionMock());
+
+  var successArg = new goog.testing.mockmatchers.ArgumentMatcher(
+      function(arg) {
+        assertTrue(arg);
+        return true;
+      });
+  var resultsArg = new goog.testing.mockmatchers.ArgumentMatcher(
+      function(arg) {
+        assertArrayEquals(arg.results,
+                          [{valid: false, recipient: 'test@example.com'},
+                           {valid: false, recipient: 't2@example.com'},
+                           {valid: true, recipient: 'cc@example.com'}]);
+        return true;
+      });
+  e2ebind.sendResponse_(resultsArg, goog.testing.mockmatchers.ignoreArgument,
+                        successArg);
+  mockControl.$replayAll();
+
+  e2ebind.handleProviderRequest_({
+    action: actions.VALIDATE_RECIPIENTS,
+    args: {recipients: RECIPIENTS}
+  });
+  mockControl.$verifyAll();
+}
+
+
+function testGetCurrentMessage() {
+  var action = constants.e2ebind.responseActions.GET_CURRENT_MESSAGE;
+  var text = 'some text';
+
+  providerRequestHandler = function(data) {
+    data.success = true;
+    data.result = {text: text};
+    return data;
+  };
+
+  e2ebind.start();
+
+  asyncTestCase.waitForAsync('waiting for e2ebind to get current message');
+  e2ebind.getCurrentMessage(function(response) {
+    assertEquals(response.text, text);
+    asyncTestCase.continueTesting();
+  });
+}
+
+
+function testHasDraft() {
+  var action = constants.e2ebind.responseActions.HAS_DRAFT;
+  providerRequestHandler = function(data) {
+    data.success = true;
+    data.result = {has_draft: true};
+    return data;
+  };
+
+  e2ebind.start();
+
+  asyncTestCase.waitForAsync('waiting for hasDraft');
+  e2ebind.hasDraft(function(response) {
+    assertTrue(response);
+    asyncTestCase.continueTesting();
+  });
+}
+
+
+function testGetDraft() {
+  var action = constants.e2ebind.responseActions.GET_DRAFT;
+  providerRequestHandler = function(data) {
+    data.success = true;
+    data.result = draft;
+    return data;
+  };
+
+  e2ebind.start();
+
+  asyncTestCase.waitForAsync('waiting for getDraft');
+  e2ebind.getDraft(function(response) {
+    assertEquals(draft.to, response.to);
+    assertEquals(draft.bcc, response.bcc);
+    assertEquals(draft.cc, response.cc);
+    assertEquals(draft.body, response.body);
+    assertEquals(draft.subject, response.subject);
+    asyncTestCase.continueTesting();
+  });
+}
+
+
+function testSetDraft() {
+  var action = constants.e2ebind.responseActions.SET_DRAFT;
+  providerRequestHandler = function(data) {
+    var response = data.args;
+    assertEquals(draft.to, response.to);
+    assertEquals(draft.bcc, response.bcc);
+    assertEquals(draft.cc, response.cc);
+    assertEquals(draft.body, response.body);
+    assertEquals(draft.subject, response.subject);
+    asyncTestCase.continueTesting();
+    return data;
+  };
+
+  e2ebind.start();
+
+  asyncTestCase.waitForAsync('waiting for setDraft');
+  e2ebind.setDraft(draft);
+}

--- a/src/javascript/crypto/e2e/extension/helper/gmonkey.js
+++ b/src/javascript/crypto/e2e/extension/helper/gmonkey.js
@@ -22,10 +22,10 @@ goog.provide('e2e.ext.gmonkey');
 
 goog.require('e2e.ext.utils.text');
 goog.require('goog.array');
-goog.require('goog.format.EmailAddress');
 
 goog.scope(function() {
 var gmonkey = e2e.ext.gmonkey;
+var utils = e2e.ext.utils;
 
 
 /**
@@ -92,45 +92,6 @@ gmonkey.isAvailable = function(callback) {
 
 
 /**
- * Extracts valid email addresses out of a string with comma-separated full
- *  email labels (e.g. "John Smith" <john@example.com>, Second
- *  <second@example.org>).
- * @param {string} emailLabels The full email labels
- * @return {!Array.<string>} The extracted valid email addresses.
- * @private
- */
-gmonkey.getValidEmailAddressesFromString_ = function(emailLabels) {
-  var emails = goog.format.EmailAddress.parseList(emailLabels);
-  return goog.array.filter(
-      goog.array.map(
-          goog.array.map(emails, function(email) {return email.toString()}),
-          e2e.ext.utils.text.extractValidEmail),
-      goog.isDefAndNotNull);
-};
-
-
-/**
- * Extracts valid email addresses out of an array with full email labels
- * (e.g. "John Smith" <john@example.com>, Second <second@example.org>).
- * @param {!Array.<string>} recipients List of recipients
- * @return {string} Comma separated list of recipients with valid e-mail
- *     addresses
- * @private
- */
-gmonkey.getValidEmailAddressesFromArray_ = function(recipients) {
-  var list = [];
-  goog.array.forEach(recipients, function(recipient) {
-    var emailAddress = goog.format.EmailAddress.parse(recipient);
-    // Validate e-mail address, but add full recipient record.
-    if (e2e.ext.utils.text.extractValidEmail(emailAddress.getAddress())) {
-      list.push(emailAddress.toString());
-    }
-  });
-  return list.join(', ');
-};
-
-
-/**
  * Gets the last selected message in Gmail.
  * @param {!function(Element)} callback The callback where the element
  *     containing the last selected message should be passed.
@@ -159,8 +120,8 @@ gmonkey.getActiveDraft = function(callback) {
 
     if (goog.isObject(result)) {
       goog.array.extend(recipients,
-          gmonkey.getValidEmailAddressesFromString_(result['to']),
-          gmonkey.getValidEmailAddressesFromString_(result['cc']));
+          utils.text.getValidEmailAddressesFromString(result['to']),
+          utils.text.getValidEmailAddressesFromString(result['cc']));
       // Document.implementation.createHTMLDocument creates a new document
       // in which the scripts are not executing and network requests are not
       // made (in Chrome), so we don't create a XSS risk here.
@@ -202,7 +163,7 @@ gmonkey.setActiveDraft = function(recipients, msgBody, opt_callback) {
     callback = opt_callback;
   }
   gmonkey.callGmonkey_('setActiveDraft', callback, {
-    to: gmonkey.getValidEmailAddressesFromArray_(recipients),
+    to: utils.text.getValidEmailAddressesFromArray(recipients).join(', '),
     body: msgBody
   });
 };

--- a/src/javascript/crypto/e2e/extension/manifest.json
+++ b/src/javascript/crypto/e2e/extension/manifest.json
@@ -12,6 +12,12 @@
     "default_icon": "images/icon-128.png",
     "default_popup": "prompt.html"
   },
+  "content_scripts": [
+    {
+      "matches": ["https://*.mail.yahoo.com/*"],
+      "js": ["helper_binary.js"]
+    }
+  ],
   "icons": {
     "16": "images/icon-16.png",
     "48": "images/icon-48.png",

--- a/src/javascript/crypto/e2e/extension/messages.js
+++ b/src/javascript/crypto/e2e/extension/messages.js
@@ -23,6 +23,9 @@ goog.provide('e2e.ext.messages.ApiResponse');
 goog.provide('e2e.ext.messages.BridgeMessageRequest');
 goog.provide('e2e.ext.messages.BridgeMessageResponse');
 goog.provide('e2e.ext.messages.GetSelectionRequest');
+goog.provide('e2e.ext.messages.e2ebindDraft');
+goog.provide('e2e.ext.messages.e2ebindRequest');
+goog.provide('e2e.ext.messages.e2ebindResponse');
 
 
 goog.scope(function() {
@@ -63,7 +66,8 @@ messages.BridgeMessageResponse;
  * selection is made.
  * @typedef {{
  *   editableElem: boolean,
- *   enableLookingGlass: boolean
+ *   enableLookingGlass: boolean,
+ *   composeGlass: (boolean|undefined)
  * }}
  */
 messages.GetSelectionRequest;
@@ -121,5 +125,47 @@ messages.ApiRequest.prototype.action;
  * }}
  */
 messages.ApiResponse;
+
+
+/**
+ * Defines the request message from the e2ebind API to a provider and from
+ *   provider to e2ebind API.
+ * @typedef {{
+ *   api: string,
+ *   source: string,
+ *   action: string,
+ *   args: (Object|undefined),
+ *   hash: string
+ * }}
+ */
+messages.e2ebindRequest;
+
+
+/**
+ * Defines the response message from the e2ebind API to a provider and from
+ *   provider to e2ebind API.
+ * @typedef {{
+ *   api: string,
+ *   source: string,
+ *   success: boolean,
+ *   action: string,
+ *   hash: string,
+ *   result: Object
+ * }}
+ */
+messages.e2ebindResponse;
+
+
+/**
+ * Defines e2ebind draft format that the provider receives.
+ * @typedef {{
+ *   body: string,
+ *   to: !Array.<string>,
+ *   cc: Array.<string>,
+ *   bcc: Array.<string>,
+ *   subject: (string|undefined)
+ * }}
+ */
+messages.e2ebindDraft;
 
 });  // goog.scope

--- a/src/javascript/crypto/e2e/extension/ui/glass/bootstrap.js
+++ b/src/javascript/crypto/e2e/extension/ui/glass/bootstrap.js
@@ -26,7 +26,8 @@ goog.provide('e2e.ext.ui.glass.bootstrap');
 
 // Create the looking glass.
 window.addEventListener('message', function(evt) {
-  if (!e2e.ext.utils.text.isGmailOrigin(evt.origin)) {
+  if (!e2e.ext.utils.text.isGmailOrigin(evt.origin) &&
+      !e2e.ext.utils.text.isYmailOrigin(evt.origin)) {
     return;
   }
 

--- a/src/javascript/crypto/e2e/extension/ui/glass/glasswrapper.js
+++ b/src/javascript/crypto/e2e/extension/ui/glass/glasswrapper.js
@@ -35,10 +35,11 @@ var ui = e2e.ext.ui;
 /**
  * Constructor for the looking glass wrapper.
  * @param {Element} targetElem The element that will host the looking glass.
+ * @param {string=} opt_text Optional text to be decrypted in the glass.
  * @constructor
  * @extends {goog.Disposable}
  */
-ui.GlassWrapper = function(targetElem) {
+ui.GlassWrapper = function(targetElem, opt_text) {
   goog.base(this);
 
   /**
@@ -47,7 +48,15 @@ ui.GlassWrapper = function(targetElem) {
    * @private
    */
   this.targetElem_ = targetElem;
-  this.targetElem_.setAttribute('original_content', this.targetElem_.innerText);
+  this.targetElem_.setAttribute('original_content', opt_text ? opt_text :
+                                this.targetElem_.innerText);
+
+  /**
+   * The original text associated with the glass.
+   * @type {(string|undefined)}
+   * @private
+   */
+  this.originalText_ = opt_text;
 
   /**
    * The original children of the target element.
@@ -80,7 +89,8 @@ ui.GlassWrapper.prototype.installGlass = function() {
   goog.style.setSize(glassFrame, goog.style.getSize(this.targetElem_));
   glassFrame.style.border = 0;
 
-  var pgpMessage = this.targetElem_.innerText;
+  var pgpMessage = this.originalText_ ? this.originalText_ :
+      this.targetElem_.innerText;
   this.targetElem_.textContent = '';
   // TODO(radi): Render in a shadow DOM.
   this.targetElem_.appendChild(glassFrame);

--- a/src/javascript/crypto/e2e/extension/utils/text.js
+++ b/src/javascript/crypto/e2e/extension/utils/text.js
@@ -119,6 +119,49 @@ utils.extractValidEmail = function(recipient) {
 
 
 /**
+ * Extracts valid email addresses out of a string with comma-separated full
+ *  email labels (e.g. "John Smith" <john@example.com>, Second
+ *  <second@example.org>).
+ * @param {string} emailLabels The full email labels
+ * @return {!Array.<string>} The extracted valid email addresses.
+ */
+utils.getValidEmailAddressesFromString = function(emailLabels) {
+  var emails = goog.format.EmailAddress.parseList(emailLabels);
+  return goog.array.filter(
+      goog.array.map(
+          goog.array.map(emails, function(email) {return email.toString()}),
+          utils.extractValidEmail),
+      goog.isDefAndNotNull);
+};
+
+
+/**
+ * Extracts valid email addresses out of an array with full email labels
+ * (e.g. "John Smith" <john@example.com>, Second <second@example.org>).
+ * @param {!Array.<string>} recipients List of recipients
+ * @param {boolean=} opt_email_only If true, return email addresses instead of
+ *   full recipient records.
+ * @return {!Array.<string>} List of emails/recipients with valid e-mails
+ */
+utils.getValidEmailAddressesFromArray = function(recipients, opt_email_only) {
+  var list = [];
+  goog.array.forEach(recipients, function(recipient) {
+    var emailAddress = goog.format.EmailAddress.parse(recipient);
+    var validEmail = utils.extractValidEmail(emailAddress.getAddress());
+    if (validEmail) {
+      if (opt_email_only) {
+        list.push(validEmail);
+      } else {
+        // Add full recipient record
+        list.push(emailAddress.toString());
+      }
+    }
+  });
+  return list;
+};
+
+
+/**
  * Checks whether a URI is an HTTPS ymail origin.
  * @param {!string} uri
  * @return {boolean}

--- a/src/javascript/crypto/e2e/extension/utils/text_test.js
+++ b/src/javascript/crypto/e2e/extension/utils/text_test.js
@@ -30,6 +30,24 @@ goog.setTestOnly();
 
 var utils = e2e.ext.utils.text;
 
+var emailString = 'test@example.com, "we <ird>>\'>, <a@a.com>, n<ess"' +
+    '<t2@example.com>, "inv\"<alid <invalid@example.com>, fails#e2e.reg' +
+    'exp.vali@dation.com, <not-an-email>, y <yan@y.com >, "user id" <fo' +
+    'o@b.com>';
+
+var emailArray = ['test@example.com',
+  '"we <ird>>\'>, <a@a.com>, n<ess"<t2@example.com>',
+  '"inv\"<alid <invalid@example.com>',
+  'fails#e2e.regexp.vali@dation.com', '<not-an-email>', 'y <yan@y.com >',
+  '"user id" <foo@b.com>'];
+
+var validRecipients = ['test@example.com',
+  '"we <ird>>\'>, <a@a.com>, n<ess" <t2@example.com>',
+  'y <yan@y.com>', 'user id <foo@b.com>'];
+
+var validEmails = ['test@example.com', 't2@example.com', 'yan@y.com',
+                   'foo@b.com'];
+
 
 function testPrettyTextWrap() {
   var inputStr = '123 456 7890 12 3456 7890';
@@ -82,6 +100,22 @@ function testExtractValidEmail() {
       utils.extractValidEmail('"inv\"<alid <invalid@example.com>'));
   assertEquals(null,
       utils.extractValidEmail('fails#e2e.regexp.vali@dation.com'));
+}
+
+
+function testGetValidEmailAddressesFromString() {
+  assertArrayEquals(validEmails,
+      utils.getValidEmailAddressesFromString(emailString));
+}
+
+
+function testGetValidEmailAddressesFromArray() {
+  assertArrayEquals(validEmails,
+                    utils.getValidEmailAddressesFromArray(
+      emailArray, true));
+  assertArrayEquals(validRecipients,
+                    utils.getValidEmailAddressesFromArray(
+      emailArray, false));
 }
 
 


### PR DESCRIPTION
Sorry this patch ended up being long. It adds support for the "e2ebind" API that allows interaction between End to End and Yahoo mail pages, reproducing all the functionality that gmonkey provides on GMail.

* Adds e2ebind module.
* Refactor email address processing out of gmonkey into separate utility methods.
* Adds two API methods that are needed by Yahoo mail content script: `LIST_ALL_UIDS` and `GET_KEYRING_UNLOCKED`. 
* Runs helper script automatically on ymail pages by declaration in manifest.json, since ymail will always have the e2ebind module loaded. Maybe there is a reason not to do this?

Note that this commit causes the following linter error. I'm not sure why. 
```
----- FILE  :  /path/to/end-to-end/extension/helper/e2ebind.js -----
Line 39, E:0142: Missing the following goog.require statements:
goog.require('e2e.ext.e2ebind.messagingTable');

First line where required: 
  e2e.ext.e2ebind.messagingTable : line 259

Found 1 errors, including 0 new errors, in 1 files (0 files OK).
```