### PR TITLE
Add builder and parser for PGP/MIME messages

### DIFF
--- a/src/javascript/crypto/e2e/extension/constants.js
+++ b/src/javascript/crypto/e2e/extension/constants.js
@@ -23,6 +23,7 @@ goog.provide('e2e.ext.constants.Actions');
 goog.provide('e2e.ext.constants.BackupCode');
 goog.provide('e2e.ext.constants.CssClass');
 goog.provide('e2e.ext.constants.ElementId');
+goog.provide('e2e.ext.constants.Mime');
 goog.provide('e2e.ext.constants.StorageKey');
 
 
@@ -225,3 +226,43 @@ e2e.ext.constants.BackupCode = {
  * @const
  */
 e2e.ext.constants.BACKUP_CODE_LENGTH = 24;
+
+
+/**
+ * MIME constants used by the extension.
+ * @enum {string}
+ */
+e2e.ext.constants.Mime = {
+  // Separators
+  CRLF: '\r\n',
+
+  // Header names
+  CONTENT_TYPE: 'Content-Type',
+  CONTENT_TRANSFER_ENCODING: 'Content-Transfer-Encoding',
+  MIME_VERSION: 'Mime-Version',
+  CONTENT_DISPOSITION: 'Content-Disposition',
+
+  // OpenPGP version content field. Required by RFC 3156.
+  VERSION_CONTENT: 'Version: 1',
+
+  // Content Types. Case-insensitive.
+  PLAINTEXT: 'text/plain',
+  MULTIPART_ENCRYPTED: 'multipart/encrypted',
+  ENCRYPTED: 'application/pgp-encrypted',
+  OCTET_STREAM: 'application/octet-stream',
+  MULTIPART_MIXED: 'multipart/mixed',
+  DEFAULT_ENCRYPTED_CONTENT_TYPE:
+      'multipart/encrypted; protocol=application/pgp-encrypted',
+
+  // Content Transfer Encodings
+  SEVEN_BIT: '7bit',
+  QUOTED_PRINTABLE: 'quoted_printable',
+  BASE64: 'base64',
+
+  // Content dispositions
+  ATTACHMENT: 'attachment',
+
+  // Charset. Case-insensitive.
+  UTF8: 'utf-8',
+  ASCII: 'us-ascii'
+};

--- a/src/javascript/crypto/e2e/extension/mime/mimenode.js
+++ b/src/javascript/crypto/e2e/extension/mime/mimenode.js
@@ -1,0 +1,184 @@
+/**
+ * @license
+ * Copyright 2014 Google Inc. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview MIME nodes for building PGP/MIME emails.
+ * @author yzhu@yahoo-inc.com (Yan Zhu)
+ */
+
+goog.provide('e2e.ext.mime.MimeNode');
+
+goog.require('e2e.ext.constants.Mime');
+goog.require('e2e.ext.mime.utils');
+goog.require('goog.array');
+goog.require('goog.crypt.base64');
+goog.require('goog.object');
+goog.require('goog.string');
+
+goog.scope(function() {
+var ext = e2e.ext;
+var constants = e2e.ext.constants;
+
+
+
+/**
+ * Constructor for a MIME tree node.
+ * @param {{
+ *   contentType: string,
+ *   contentTransferEncoding: (string|undefined),
+ *   multipart: boolean
+ * }} options Options to initialize for the node.
+ * @param {e2e.ext.mime.MimeNode=} opt_parent The parent node.
+ * @param {string=} opt_filename Name of the file, if the node is an attachment.
+ *   to false.
+ * @constructor
+ */
+ext.mime.MimeNode = function(options, opt_parent, opt_filename) {
+  this.parent = opt_parent || this;
+  this.filename = opt_filename;
+
+  this.multipart_ = options.multipart;
+  this.children_ = [];
+  this.header_ = /** @type {e2e.ext.mime.types.Header} */ ({});
+  this.content_ = null;
+  this.boundary_ = '';
+
+  this.setHeader_(constants.Mime.CONTENT_TYPE, options.contentType);
+
+  // Default content transfer encoding is 7bit, according to RFC 2045
+  var ctEncoding = options.contentTransferEncoding ?
+      options.contentTransferEncoding : constants.Mime.SEVEN_BIT;
+  this.setHeader_(constants.Mime.CONTENT_TRANSFER_ENCODING, ctEncoding);
+
+  this.setBoundary_();
+};
+
+
+/**
+ * Sets the MIME message boundary for a node.
+ * @private
+ */
+ext.mime.MimeNode.prototype.setBoundary_ = function() {
+  // TODO: Strictly ensure that the boundary value doesn't coincide with
+  //   any string in the email content and headers.
+  this.boundary_ = '---' + goog.string.getRandomString() +
+      Math.floor(Date.now() / 1000).toString();
+};
+
+
+/**
+ * Adds a child to a MIME node.
+ * @param {{
+ *   contentType: string,
+ *   contentTransferEncoding: (string|undefined),
+ *   multipart: boolean
+ * }} options Options to initialize for the node.
+ * @param {string=} opt_filename Name of the file, if one exists.
+ * @return {e2e.ext.mime.MimeNode}
+ */
+ext.mime.MimeNode.prototype.addChild = function(options, opt_filename) {
+  var node = new ext.mime.MimeNode(options, this, opt_filename);
+  this.children_.push(node);
+  return node;
+};
+
+
+/**
+ * Sets a MIME header.
+ * @param {string} key Name of the header.
+ * @param {string} value Value of the header, possibly including parameters.
+ * @param {Object.<string, string>=} opt_params Optional dict of additional
+ *   parameters
+ * @private
+ */
+ext.mime.MimeNode.prototype.setHeader_ = function(key, value, opt_params) {
+  var headerValue = ext.mime.utils.parseHeaderValue(value);
+  if (opt_params) {
+    headerValue.params = headerValue.params || {};
+    goog.object.extend(headerValue.params, opt_params);
+  }
+  goog.object.set(this.header_, key, headerValue);
+};
+
+
+/**
+ * Sets the content.
+ * @param {(string|!e2e.byteArray)} content The content to set
+ */
+ext.mime.MimeNode.prototype.setContent = function(content) {
+  this.content_ = content;
+};
+
+
+/**
+ * Builds an RFC 2822 message from the node and its children.
+ * @return {string}
+ */
+ext.mime.MimeNode.prototype.buildMessage = function() {
+  var lines = [];
+  var transferEncoding =
+      this.header_[constants.Mime.CONTENT_TRANSFER_ENCODING];
+  var contentType = this.header_[constants.Mime.CONTENT_TYPE];
+
+  // Set required header fields
+  if (this.filename && !this.header_[constants.Mime.CONTENT_DISPOSITION]) {
+    // Set the correct content disposition header for attachments.
+    this.setHeader_(constants.Mime.CONTENT_DISPOSITION,
+                    constants.Mime.ATTACHMENT,
+                    {filename: this.filename});
+  } else if (this.content_ && goog.typeOf(this.content_) === 'string') {
+    // TODO: Support other charsets.
+    contentType.params.charset = contentType.params.charset ||
+        constants.Mime.UTF8;
+  } else if (this.multipart_) {
+    // Multipart messages need to specify a boundary
+    contentType.params.boundary = this.boundary_;
+  }
+
+  // TODO: Wrap header lines at 76 chars
+  lines = lines.concat(ext.mime.utils.serializeHeader(this.header_));
+
+  lines.push('');
+
+  if (this.content_) {
+    if (transferEncoding.value === constants.Mime.BASE64 ||
+        goog.typeOf(this.content_) !== 'string') {
+      // TODO: Wrap lines at 76 chars
+      lines.push(goog.typeOf(this.content_) === 'string' ?
+                 goog.crypt.base64.encodeString(this.content_) :
+                 goog.crypt.base64.encodeByteArray(this.content_));
+    } else {
+      // TODO: Technically lines must be wrapped at 1000 chars max for SMTP.
+      lines.push(this.content_);
+    }
+    if (this.multipart_) {
+      lines.push('');
+    }
+  }
+
+  if (this.multipart_) {
+    goog.array.forEach(this.children_, goog.bind(function(node) {
+      lines.push('--' + this.boundary_);
+      lines.push(node.buildMessage());
+    }, this));
+    lines.push('--' + this.boundary_ + '--');
+    lines.push('');
+  }
+
+  return lines.join(constants.Mime.CRLF);
+};
+
+});  // goog.scope

--- a/src/javascript/crypto/e2e/extension/mime/mimenode_test.html
+++ b/src/javascript/crypto/e2e/extension/mime/mimenode_test.html
@@ -1,0 +1,25 @@
+<!-- Copyright 2013 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -->
+<!DOCTYPE html>
+<html>
+<head>
+<title>Unit Test of e2e.ext.mime.MimeNode</title>
+<script src="../../../../../../javascript/closure/base.js"></script>
+<script src="test_js_deps-runfiles.js"></script>
+<script>
+  goog.require('e2e.ext.mime.MimeNodeTest');
+</script>
+</head>
+</html>

--- a/src/javascript/crypto/e2e/extension/mime/mimenode_test.js
+++ b/src/javascript/crypto/e2e/extension/mime/mimenode_test.js
@@ -1,0 +1,164 @@
+/**
+ * @license
+ * Copyright 2014 Google Inc. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Tests for the MIME node builder/parser.
+ */
+
+/** @suppress {extraProvide} */
+goog.provide('e2e.ext.mime.MimeNodeTest');
+
+goog.require('e2e.ext.constants');
+goog.require('e2e.ext.mime.MimeNode');
+goog.require('e2e.ext.testingstubs');
+goog.require('goog.testing.PropertyReplacer');
+goog.require('goog.testing.asserts');
+goog.require('goog.testing.jsunit');
+goog.setTestOnly();
+
+var constants = e2e.ext.constants;
+var node = null;
+var filename = 'example.txt';
+var stubs = new goog.testing.PropertyReplacer();
+
+var BINARY_CONTENT = '\x98\x8d\x04\x52\xb0\xe5\x09\x01\x04\x00' +
+    '\xd7\x6f\x47\x2e\x0d\x18\x1a\x84\xdb\x42\xe4\x37\x86\xb0\xef' +
+    '\x50\x85\x2f\x52\xec\x89\x43\xd9\xc8\xdc\x42\x32\xd9\xc5\xb1' +
+    '\x13\x06\x12\xc2\xc3\x21\x41\xc6\x58\xa0\xfa\x37\xb9\xa2\x3e' +
+    '\x27\x56\x9c\x52\x74\x34\x8f\xae\x8f\xaa\xae\x2a\x52\x9b\xaf' +
+    '\xee\xaf\x5d\xa3\x27\xbf\xd6\x21\x89\x32\xd2\x46\x8f\xcc\x35' +
+    '\xf7\x0a\xf7\x21\x29\xe4\x5e\x41\x64\x4d\x30\xb2\xbd\xb5\x7f' +
+    '\xc3\x5f\xbc\x83\x75\x2a\x2f\xcb\x5d\x61\xfa\x1e\xd4\xd8\xeb' +
+    '\x2c\x62\x26\xfd\x12\x06\xd4\x45\x3c\xcf\x5b\xf5\x30\xfc\x73' +
+    '\xcd\x80\xb5\x9e\x05\xcd\x92\x13\x00\x11\x01\x00\x01\xb4\x1a' +
+    '\x74\x65\x73\x74\x20\x35\x20\x3c\x74\x65\x73\x74\x35\x40\x65' +
+    '\x78\x61\x6d\x70\x6c\x65\x2e\x63\x6f\x6d\x3e\x88\xb8\x04\x13' +
+    '\x01\x02\x00\x22\x05\x02\x52\xb0\xe5\x09\x02\x1b\x03\x06\x0b' +
+    '\x09\x08\x07\x03\x02\x06\x15\x08\x02\x09\x0a\x0b\x04\x16\x02' +
+    '\x03\x01\x02\x1e\x01\x02\x17\x80\x00\x0a\x09\x10\x3a\x4c\x86' +
+    '\xe5\xe3\x16\xd7\xeb\x62\x6e\x03\xff\x49\x74\x72\x20\x33\xe3' +
+    '\x87\xd0\xf3\xab\x3a\x32\xdd\x2f\x92\x49\xb1\x47\x0d\xb0\x35' +
+    '\xba\x71\x68\x7e\x4d\x52\x81\xde\x8e\x07\xdd\x52\xac\xde\xf0' +
+    '\xfa\xbd\x5b\x40\x81\xd9\x59\x12\x42\x68\x3c\x6d\xc2\x38\xb4' +
+    '\xc7\xd2\x9a\xe6\x29\xb0\x3b\x58\x2b\x58\xed\x77\x08\x96\x1a' +
+    '\xb5\x80\xa6\xa6\x48\x1d\xee\x7c\xf3\x36\x93\xea\x20\xcf\x0b' +
+    '\xce\xfb\xa8\x6f\xd2\x4f\xe9\xd4\x70\x53\x7e\x88\x6c\x0d\x73' +
+    '\xb7\x71\xa8\x91\x44\xa3\xc6\xbc\xc7\x05\xa0\x71\x91\x48\xe9' +
+    '\x50\x28\xc8\xf0\x37\xf6\x80\x5d\x59\x93\xd0\x45\xaf\xb4\xb7' +
+    '\x73\x92\xb8\x8d\x04\x52\xb0\xe5\x09\x01\x04\x00\x9d\x0c\x45' +
+    '\x22\xd2\x39\x60\xf8\x4e\x67\xee\xea\x40\x01\xed\xae\x0f\xa4' +
+    '\x2c\x3f\xbe\x91\x95\xc6\x47\x05\x7c\xb1\x22\xdb\x65\x71\x02' +
+    '\x5a\xdc\xa0\x20\x94\xdf\x7a\x7d\x44\x94\xd0\x64\xd5\x58\x1c' +
+    '\x57\xb3\x05\x95\x1d\x13\xc7\xb1\x1e\x4c\xfe\x0b\x5c\x00\xc2' +
+    '\x57\x1d\x23\x52\x9a\x17\x26\xd7\x16\xa6\xf4\xe5\x0f\xfe\x15' +
+    '\x39\xe0\x5a\x6e\xd7\xf4\x2e\x19\x67\x46\x25\x7f\xb9\x44\x5e' +
+    '\xe8\x49\xe4\x71\x6e\x36\x30\x7f\x59\x8a\x3d\x10\x52\xf4\x18' +
+    '\xd6\x6d\xb8\x25\x04\x84\xf8\x32\xfc\x8a\xe2\x91\x6c\x3c\x7e' +
+    '\x3b\x26\x86\x80\x0b\x00\x11\x01\x00\x01\x88\x9f\x04\x18\x01' +
+    '\x02\x00\x09\x05\x02\x52\xb0\xe5\x09\x02\x1b\x0c\x00\x0a\x09' +
+    '\x10\x3a\x4c\x86\xe5\xe3\x16\xd7\xeb\xd6\x67\x03\xff\x7b\x88' +
+    '\xad\xb9\x8d\xc1\x45\x0f\x5d\xfa\xaa\x53\x96\x5b\x68\xb6\x7e' +
+    '\x7d\x76\xf5\xf1\x46\x52\x0f\xcf\xd6\x5e\x84\x65\xe1\xef\x2d' +
+    '\xc2\xc6\x68\xaa\x85\x65\xbd\xa2\xeb\xcb\x66\x23\x36\xb5\xc6' +
+    '\x5f\x7e\xc9\x31\xe5\x1d\x88\x9f\xc5\x09\xe9\x10\xc4\xbe\xfc' +
+    '\x26\x8f\x19\x25\x15\x54\xff\xab\x76\x56\x27\xef\x39\x24\xdf' +
+    '\x3e\x22\x02\x2d\x7e\xa4\x66\xf9\xea\x66\x16\x89\x52\xc7\xd8' +
+    '\xb7\x90\x4f\x05\x67\x97\xe7\x79\x57\x4a\xa2\xd4\x3d\xad\x3f' +
+    '\x10\x81\x6e\xcf\xe0\xff\x61\x0e\xe6\x5d\xd9\x7e\xe1\x27\xc2' +
+    '\x36\x20\x2e\xbe\x43\xd7';
+
+var TEXT_CONTENT = 'hi this is a\ntext message';
+var BOUNDARY = '--foo';
+var FINAL_MESSAGE = ['Content-Type: multipart/mixed; boundary="--foo"',
+  'Content-Transfer-Encoding: 7bit',
+  '', '----foo', 'Content-Type: text/plain; charset="utf-8"',
+  'Content-Transfer-Encoding: 7bit', '', TEXT_CONTENT, '----foo',
+  'Content-Type: application/octet-stream',
+  'Content-Transfer-Encoding: base64',
+  'Content-Disposition: attachment; filename="example.txt"', '',
+  'mI0EUrDlCQEEANdvRy4NGBqE20LkN4aw71CFL1LsiUPZyNxCMtnFsRMGEsLDIUHGWKD6N' +
+      '7miPidWnFJ0NI+uj6quKlKbr+6vXaMnv9YhiTLSRo/MNfcK9yEp5F5BZE0wsr21f8NfvI' +
+      'N1Ki/LXWH6HtTY6yxiJv0SBtRFPM9b9TD8c82AtZ4FzZITABEBAAG0GnRlc3QgNSA8dGV' +
+      'zdDVAZXhhbXBsZS5jb20+iLgEEwECACIFAlKw5QkCGwMGCwkIBwMCBhUIAgkKCwQWAgMB' +
+      'Ah4BAheAAAoJEDpMhuXjFtfrYm4D/0l0ciAz44fQ86s6Mt0vkkmxRw2wNbpxaH5NUoHej' +
+      'gfdUqze8Pq9W0CB2VkSQmg8bcI4tMfSmuYpsDtYK1jtdwiWGrWApqZIHe588zaT6iDPC8' +
+      '77qG/ST+nUcFN+iGwNc7dxqJFEo8a8xwWgcZFI6VAoyPA39oBdWZPQRa+0t3OSuI0EUrD' +
+      'lCQEEAJ0MRSLSOWD4Tmfu6kAB7a4PpCw/vpGVxkcFfLEi22VxAlrcoCCU33p9RJTQZNVY' +
+      'HFezBZUdE8exHkz+C1wAwlcdI1KaFybXFqb05Q/+FTngWm7X9C4ZZ0Ylf7lEXuhJ5HFuN' +
+      'jB/WYo9EFL0GNZtuCUEhPgy/IrikWw8fjsmhoALABEBAAGInwQYAQIACQUCUrDlCQIbDA' +
+      'AKCRA6TIbl4xbX69ZnA/97iK25jcFFD136qlOWW2i2fn129fFGUg/P1l6EZeHvLcLGaKq' +
+      'FZb2i68tmIza1xl9+yTHlHYifxQnpEMS+/CaPGSUVVP+rdlYn7zkk3z4iAi1+pGb56mYW' +
+      'iVLH2LeQTwVnl+d5V0qi1D2tPxCBbs/g/2EO5l3ZfuEnwjYgLr5D1w==',
+  '----foo--', ''].join('\r\n');
+
+
+function setUp() {
+  var boundary = '--foo';
+  e2e.ext.testingstubs.initStubs(stubs);
+  stubs.replace(e2e.ext.mime.MimeNode.prototype, 'setBoundary_', function() {
+    this.boundary_ = boundary;
+  });
+  node = new e2e.ext.mime.MimeNode({
+    contentType: constants.Mime.MULTIPART_MIXED,
+    multipart: true
+  });
+}
+
+
+function tearDown() {
+  stubs.reset();
+  node = null;
+}
+
+
+function testNodeSetup() {
+  assertEquals(BOUNDARY, node.boundary_);
+  assertTrue(node.multipart_);
+  assertEquals(constants.Mime.MULTIPART_MIXED,
+               node.header_[constants.Mime.CONTENT_TYPE].value);
+}
+
+
+function testAddChild() {
+  var child = node.addChild({contentType: constants.Mime.ENCRYPTED,
+    multipart: false}, filename);
+  assertArrayEquals(node.children_, [child]);
+  assertEquals(filename, child.filename);
+  assertEquals(node, child.parent);
+  assertEquals(constants.Mime.ENCRYPTED,
+               child.header_[constants.Mime.CONTENT_TYPE].value);
+}
+
+
+function testSetContent() {
+  node.setContent(TEXT_CONTENT);
+  assertEquals(TEXT_CONTENT, node.content_);
+}
+
+
+function testBuildMessage() {
+  var childTextNode = node.addChild({contentType: constants.Mime.PLAINTEXT,
+    multipart: false});
+  childTextNode.setContent(TEXT_CONTENT);
+  var childAttachmentNode = node.addChild({
+    contentType: constants.Mime.OCTET_STREAM,
+    multipart: false,
+    contentTransferEncoding: constants.Mime.BASE64}, filename);
+  childAttachmentNode.setContent(BINARY_CONTENT);
+
+  var builtMessage = node.buildMessage();
+  assertEquals(FINAL_MESSAGE, builtMessage);
+}

--- a/src/javascript/crypto/e2e/extension/mime/pgpmail.js
+++ b/src/javascript/crypto/e2e/extension/mime/pgpmail.js
@@ -1,0 +1,141 @@
+/**
+ * @license
+ * Copyright 2014 Google Inc. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview PGP/MIME message entity builder (RFC 2045, RFC 2822, RFC 3156).
+ * @author yzhu@yahoo-inc.com (Yan Zhu)
+ */
+
+goog.provide('e2e.ext.mime.PgpMail');
+
+goog.require('e2e.ext.constants.Actions');
+goog.require('e2e.ext.constants.Mime');
+goog.require('e2e.ext.mime.MimeNode');
+goog.require('goog.array');
+
+
+goog.scope(function() {
+var ext = e2e.ext;
+var constants = e2e.ext.constants;
+var mime = e2e.ext.mime;
+
+
+
+/**
+ * Constructs a PGP/MIME email.
+ * @param {!mime.types.MailContent} content The content of the email.
+ * @param {!e2e.ext.actions.Executor} actionExecutor Executor for the End-to-
+ *   End actions.
+ * @param {string} currentUser The author of the email.
+ * @param {boolean} signMessage Whether the message should be signed.
+ * @param {Array=} opt_recipients The recipients of the email.
+ * @param {Array=} opt_passphrases Additional passphrases for encryption.
+ * @constructor
+ */
+ext.mime.PgpMail = function(content, actionExecutor, currentUser,
+                            signMessage, opt_recipients, opt_passphrases) {
+  this.recipients = opt_recipients;
+  this.passphrases = opt_passphrases;
+  this.signMessage = signMessage;
+  this.actionExecutor_ = actionExecutor;
+  this.originalContent = content;
+  this.currentUser = currentUser;
+};
+
+
+/**
+ * Processes email into an encrypted MIME tree.
+ * @param {!function(string)} callback
+ */
+ext.mime.PgpMail.prototype.buildSignedAndEncrypted = function(callback) {
+  var mimetree = this.buildMimeTree_(this.originalContent);
+  var request = /** @type {!messages.ApiRequest} */ ({
+    action: constants.Actions.ENCRYPT_SIGN,
+    content: mimetree,
+    signMessage: this.signMessage,
+    currentUser: this.currentUser,
+    recipients: this.recipients,
+    encryptPassphrases: this.passphrases
+  });
+  this.actionExecutor_.execute(request, this, goog.bind(function(encrypted) {
+    var encryptedTree = this.buildEncryptedMimeTree_(encrypted);
+    callback(encryptedTree);
+  }, this));
+};
+
+
+/**
+ * Create a plaintext serialized MIME tree for the email.
+ * @param {!mime.types.MailContent} content The plaintext content of the email.
+ * @return {string}
+ * @private
+ */
+ext.mime.PgpMail.prototype.buildMimeTree_ = function(content) {
+  var rootNode;
+
+  if (!content.attachments || content.attachments.length === 0) {
+    // Create a single plaintext node.
+    rootNode = new mime.MimeNode({multipart: false,
+      contentType: constants.Mime.PLAINTEXT});
+    rootNode.setContent(content.body);
+  } else {
+    // Create a multipart node with children for body and attachments.
+    rootNode = new mime.MimeNode({multipart: true,
+      contentType: constants.Mime.MULTIPART_MIXED});
+
+    var textNode = rootNode.addChild({multipart: false,
+      contentType: constants.Mime.PLAINTEXT});
+    textNode.setContent(content.body);
+
+    goog.array.forEach(content.attachments, function(attachment) {
+      var filename = attachment.filename;
+      var options = {multipart: false,
+        contentType: constants.Mime.OCTET_STREAM,
+        contentTransferEncoding: constants.Mime.BASE64};
+
+      var attachmentNode = rootNode.addChild(options, filename);
+      attachmentNode.setContent(attachment.content);
+    });
+  }
+  return rootNode.buildMessage();
+};
+
+
+/**
+ * Builds a serialized MIME tree for PGP-encrypted content, per RFC 3156.
+ * @param {string} encrypted The PGP-encrypted content.
+ * @return {string}
+ * @private
+ */
+ext.mime.PgpMail.prototype.buildEncryptedMimeTree_ = function(encrypted) {
+  // Build the top-level node
+  var rootNode = new mime.MimeNode({multipart: true,
+    contentType: constants.Mime.DEFAULT_ENCRYPTED_CONTENT_TYPE});
+
+  // Set the required version info.
+  var versionNode = rootNode.addChild({multipart: false,
+    contentType: constants.Mime.ENCRYPTED});
+  versionNode.setContent(constants.Mime.VERSION_CONTENT);
+
+  // Set the ciphertext
+  var contentNode = rootNode.addChild({multipart: false,
+    contentType: constants.Mime.OCTET_STREAM});
+  contentNode.setContent(encrypted);
+
+  return rootNode.buildMessage();
+};
+
+});  // goog.scope

--- a/src/javascript/crypto/e2e/extension/mime/pgpmail_test.html
+++ b/src/javascript/crypto/e2e/extension/mime/pgpmail_test.html
@@ -1,0 +1,25 @@
+<!-- Copyright 2013 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -->
+<!DOCTYPE html>
+<html>
+<head>
+<title>Unit Test of e2e.ext.mime.PgpMail</title>
+<script src="../../../../../../javascript/closure/base.js"></script>
+<script src="test_js_deps-runfiles.js"></script>
+<script>
+  goog.require('e2e.ext.mime.PgpMailTest');
+</script>
+</head>
+</html>

--- a/src/javascript/crypto/e2e/extension/mime/pgpmail_test.js
+++ b/src/javascript/crypto/e2e/extension/mime/pgpmail_test.js
@@ -1,0 +1,179 @@
+/**
+ * @license
+ * Copyright 2014 Google Inc. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Tests for the PGP/MIME email builder.
+ */
+
+/** @suppress {extraProvide} */
+goog.provide('e2e.ext.mime.PgpMailTest');
+
+goog.require('e2e.ext.actions.Executor');
+goog.require('e2e.ext.constants');
+goog.require('e2e.ext.mime.MimeNode');
+goog.require('e2e.ext.mime.PgpMail');
+goog.require('e2e.ext.testingstubs');
+goog.require('goog.testing.MockControl');
+goog.require('goog.testing.PropertyReplacer');
+goog.require('goog.testing.asserts');
+goog.require('goog.testing.jsunit');
+goog.require('goog.testing.mockmatchers');
+goog.setTestOnly();
+
+var constants = e2e.ext.constants;
+var mockControl = null;
+var mockmatchers = goog.testing.mockmatchers;
+var node = null;
+var filename = 'example.txt';
+var stubs = new goog.testing.PropertyReplacer();
+
+var BINARY_CONTENT = '\x98\x8d\x04\x52\xb0\xe5\x09\x01\x04\x00' +
+    '\xd7\x6f\x47\x2e\x0d\x18\x1a\x84\xdb\x42\xe4\x37\x86\xb0\xef' +
+    '\x50\x85\x2f\x52\xec\x89\x43\xd9\xc8\xdc\x42\x32\xd9\xc5\xb1' +
+    '\x13\x06\x12\xc2\xc3\x21\x41\xc6\x58\xa0\xfa\x37\xb9\xa2\x3e' +
+    '\x27\x56\x9c\x52\x74\x34\x8f\xae\x8f\xaa\xae\x2a\x52\x9b\xaf' +
+    '\xee\xaf\x5d\xa3\x27\xbf\xd6\x21\x89\x32\xd2\x46\x8f\xcc\x35' +
+    '\xf7\x0a\xf7\x21\x29\xe4\x5e\x41\x64\x4d\x30\xb2\xbd\xb5\x7f' +
+    '\xc3\x5f\xbc\x83\x75\x2a\x2f\xcb\x5d\x61\xfa\x1e\xd4\xd8\xeb' +
+    '\x2c\x62\x26\xfd\x12\x06\xd4\x45\x3c\xcf\x5b\xf5\x30\xfc\x73' +
+    '\xcd\x80\xb5\x9e\x05\xcd\x92\x13\x00\x11\x01\x00\x01\xb4\x1a' +
+    '\x74\x65\x73\x74\x20\x35\x20\x3c\x74\x65\x73\x74\x35\x40\x65' +
+    '\x78\x61\x6d\x70\x6c\x65\x2e\x63\x6f\x6d\x3e\x88\xb8\x04\x13' +
+    '\x01\x02\x00\x22\x05\x02\x52\xb0\xe5\x09\x02\x1b\x03\x06\x0b' +
+    '\x09\x08\x07\x03\x02\x06\x15\x08\x02\x09\x0a\x0b\x04\x16\x02' +
+    '\x03\x01\x02\x1e\x01\x02\x17\x80\x00\x0a\x09\x10\x3a\x4c\x86' +
+    '\xe5\xe3\x16\xd7\xeb\x62\x6e\x03\xff\x49\x74\x72\x20\x33\xe3' +
+    '\x87\xd0\xf3\xab\x3a\x32\xdd\x2f\x92\x49\xb1\x47\x0d\xb0\x35' +
+    '\xba\x71\x68\x7e\x4d\x52\x81\xde\x8e\x07\xdd\x52\xac\xde\xf0' +
+    '\xfa\xbd\x5b\x40\x81\xd9\x59\x12\x42\x68\x3c\x6d\xc2\x38\xb4' +
+    '\xc7\xd2\x9a\xe6\x29\xb0\x3b\x58\x2b\x58\xed\x77\x08\x96\x1a' +
+    '\xb5\x80\xa6\xa6\x48\x1d\xee\x7c\xf3\x36\x93\xea\x20\xcf\x0b' +
+    '\xce\xfb\xa8\x6f\xd2\x4f\xe9\xd4\x70\x53\x7e\x88\x6c\x0d\x73' +
+    '\xb7\x71\xa8\x91\x44\xa3\xc6\xbc\xc7\x05\xa0\x71\x91\x48\xe9' +
+    '\x50\x28\xc8\xf0\x37\xf6\x80\x5d\x59\x93\xd0\x45\xaf\xb4\xb7' +
+    '\x73\x92\xb8\x8d\x04\x52\xb0\xe5\x09\x01\x04\x00\x9d\x0c\x45' +
+    '\x22\xd2\x39\x60\xf8\x4e\x67\xee\xea\x40\x01\xed\xae\x0f\xa4' +
+    '\x2c\x3f\xbe\x91\x95\xc6\x47\x05\x7c\xb1\x22\xdb\x65\x71\x02' +
+    '\x5a\xdc\xa0\x20\x94\xdf\x7a\x7d\x44\x94\xd0\x64\xd5\x58\x1c' +
+    '\x57\xb3\x05\x95\x1d\x13\xc7\xb1\x1e\x4c\xfe\x0b\x5c\x00\xc2' +
+    '\x57\x1d\x23\x52\x9a\x17\x26\xd7\x16\xa6\xf4\xe5\x0f\xfe\x15' +
+    '\x39\xe0\x5a\x6e\xd7\xf4\x2e\x19\x67\x46\x25\x7f\xb9\x44\x5e' +
+    '\xe8\x49\xe4\x71\x6e\x36\x30\x7f\x59\x8a\x3d\x10\x52\xf4\x18' +
+    '\xd6\x6d\xb8\x25\x04\x84\xf8\x32\xfc\x8a\xe2\x91\x6c\x3c\x7e' +
+    '\x3b\x26\x86\x80\x0b\x00\x11\x01\x00\x01\x88\x9f\x04\x18\x01' +
+    '\x02\x00\x09\x05\x02\x52\xb0\xe5\x09\x02\x1b\x0c\x00\x0a\x09' +
+    '\x10\x3a\x4c\x86\xe5\xe3\x16\xd7\xeb\xd6\x67\x03\xff\x7b\x88' +
+    '\xad\xb9\x8d\xc1\x45\x0f\x5d\xfa\xaa\x53\x96\x5b\x68\xb6\x7e' +
+    '\x7d\x76\xf5\xf1\x46\x52\x0f\xcf\xd6\x5e\x84\x65\xe1\xef\x2d' +
+    '\xc2\xc6\x68\xaa\x85\x65\xbd\xa2\xeb\xcb\x66\x23\x36\xb5\xc6' +
+    '\x5f\x7e\xc9\x31\xe5\x1d\x88\x9f\xc5\x09\xe9\x10\xc4\xbe\xfc' +
+    '\x26\x8f\x19\x25\x15\x54\xff\xab\x76\x56\x27\xef\x39\x24\xdf' +
+    '\x3e\x22\x02\x2d\x7e\xa4\x66\xf9\xea\x66\x16\x89\x52\xc7\xd8' +
+    '\xb7\x90\x4f\x05\x67\x97\xe7\x79\x57\x4a\xa2\xd4\x3d\xad\x3f' +
+    '\x10\x81\x6e\xcf\xe0\xff\x61\x0e\xe6\x5d\xd9\x7e\xe1\x27\xc2' +
+    '\x36\x20\x2e\xbe\x43\xd7';
+
+var TEXT_CONTENT = 'hi this is a\ntext message';
+var BOUNDARY = '--foo';
+
+var PLAINTEXT_MESSAGE = ['Content-Type: multipart/mixed; boundary="--foo"',
+  'Content-Transfer-Encoding: 7bit',
+  '', '----foo', 'Content-Type: text/plain; charset="utf-8"',
+  'Content-Transfer-Encoding: 7bit', '', TEXT_CONTENT, '----foo',
+  'Content-Type: application/octet-stream',
+  'Content-Transfer-Encoding: base64',
+  'Content-Disposition: attachment; filename="example.txt"', '',
+  'mI0EUrDlCQEEANdvRy4NGBqE20LkN4aw71CFL1LsiUPZyNxCMtnFsRMGEsLDIUHGWKD6N' +
+      '7miPidWnFJ0NI+uj6quKlKbr+6vXaMnv9YhiTLSRo/MNfcK9yEp5F5BZE0wsr21f8NfvI' +
+      'N1Ki/LXWH6HtTY6yxiJv0SBtRFPM9b9TD8c82AtZ4FzZITABEBAAG0GnRlc3QgNSA8dGV' +
+      'zdDVAZXhhbXBsZS5jb20+iLgEEwECACIFAlKw5QkCGwMGCwkIBwMCBhUIAgkKCwQWAgMB' +
+      'Ah4BAheAAAoJEDpMhuXjFtfrYm4D/0l0ciAz44fQ86s6Mt0vkkmxRw2wNbpxaH5NUoHej' +
+      'gfdUqze8Pq9W0CB2VkSQmg8bcI4tMfSmuYpsDtYK1jtdwiWGrWApqZIHe588zaT6iDPC8' +
+      '77qG/ST+nUcFN+iGwNc7dxqJFEo8a8xwWgcZFI6VAoyPA39oBdWZPQRa+0t3OSuI0EUrD' +
+      'lCQEEAJ0MRSLSOWD4Tmfu6kAB7a4PpCw/vpGVxkcFfLEi22VxAlrcoCCU33p9RJTQZNVY' +
+      'HFezBZUdE8exHkz+C1wAwlcdI1KaFybXFqb05Q/+FTngWm7X9C4ZZ0Ylf7lEXuhJ5HFuN' +
+      'jB/WYo9EFL0GNZtuCUEhPgy/IrikWw8fjsmhoALABEBAAGInwQYAQIACQUCUrDlCQIbDA' +
+      'AKCRA6TIbl4xbX69ZnA/97iK25jcFFD136qlOWW2i2fn129fFGUg/P1l6EZeHvLcLGaKq' +
+      'FZb2i68tmIza1xl9+yTHlHYifxQnpEMS+/CaPGSUVVP+rdlYn7zkk3z4iAi1+pGb56mYW' +
+      'iVLH2LeQTwVnl+d5V0qi1D2tPxCBbs/g/2EO5l3ZfuEnwjYgLr5D1w==',
+  '----foo--', ''].join('\r\n');
+
+function setUp() {
+  mockControl = new goog.testing.MockControl();
+  e2e.ext.testingstubs.initStubs(stubs);
+  stubs.replace(e2e.ext.mime.MimeNode.prototype, 'setBoundary_', function() {
+    this.boundary_ = BOUNDARY;
+  });
+}
+
+
+function tearDown() {
+  stubs.reset();
+  mockControl.$tearDown();
+  node = null;
+}
+
+
+function testBuildSignedAndEncrypted() {
+  var encryptedText = 'some encrypted text';
+  var signer = 'yan@mit.edu';
+  var signMessage = true;
+  var finalTree = ['Content-Type: multipart/encrypted; ' +
+        'protocol="application/pgp-encrypted"; boundary="--foo"',
+    'Content-Transfer-Encoding: 7bit', '', '----foo',
+    'Content-Type: application/pgp-encrypted; charset="utf-8"',
+    'Content-Transfer-Encoding: 7bit', '', 'Version: 1', '----foo',
+    'Content-Type: application/octet-stream; charset="utf-8"',
+    'Content-Transfer-Encoding: 7bit', '', encryptedText,
+    '----foo--', ''].join('\r\n');
+
+
+  var actionExecutor = new e2e.ext.actions.Executor();
+  stubs.replace(e2e.ext.actions.Executor.prototype, 'execute',
+                mockControl.createFunctionMock());
+
+  var requestArg = new mockmatchers.ArgumentMatcher(function(arg) {
+    assertEquals(constants.Actions.ENCRYPT_SIGN, arg.action);
+    assertEquals(PLAINTEXT_MESSAGE, arg.content);
+    assertEquals(signer, arg.currentUser);
+    assertTrue(signMessage);
+    return true;
+  });
+
+  var cb = new mockmatchers.SaveArgument(function(arg) {
+    arg(encryptedText);
+    return true;
+  });
+
+  e2e.ext.actions.Executor.prototype.
+      execute(requestArg, mockmatchers.ignoreArgument, cb);
+
+  mockControl.$replayAll();
+
+  var arr = new Uint8Array(BINARY_CONTENT.length);
+  for (var i = 0; i < arr.length; i++) {
+    arr[i] = BINARY_CONTENT.charCodeAt(i);
+  }
+  var content = {body: TEXT_CONTENT,
+    attachments: [{filename: filename, content: arr}]};
+
+  var mail = new e2e.ext.mime.PgpMail(content, actionExecutor, signer,
+                                      signMessage);
+  mail.buildSignedAndEncrypted(function(encryptedTree) {
+    assertEquals(finalTree, encryptedTree);
+  });
+  mockControl.$verifyAll();
+}

--- a/src/javascript/crypto/e2e/extension/mime/types.js
+++ b/src/javascript/crypto/e2e/extension/mime/types.js
@@ -1,0 +1,59 @@
+/**
+ * @license
+ * Copyright 2014 Google Inc. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Type definitions for MIME modules
+ * @author yzhu@yahoo-inc.com (Yan Zhu)
+ */
+
+goog.provide('e2e.ext.mime.types.Attachment');
+goog.provide('e2e.ext.mime.types.Entity');
+goog.provide('e2e.ext.mime.types.Header');
+goog.provide('e2e.ext.mime.types.HeaderValue');
+goog.provide('e2e.ext.mime.types.MailContent');
+
+
+/**
+ * @typedef {{body: (string|undefined),
+ *     attachments: (Array.<!e2e.ext.mime.Attachment>|undefined)}}
+ */
+e2e.ext.mime.types.MailContent;
+
+
+/**
+ * @typedef {{filename: string,
+ *     content: !Uint8Array}}
+ */
+e2e.ext.mime.types.Attachment;
+
+
+/**
+ * @typedef {Object.<string, e2e.ext.mime.types.HeaderValue>}
+ */
+e2e.ext.mime.types.Header;
+
+
+/**
+ * @typedef {{value: string, params: (!Object.<string, string>|undefined)}}
+ */
+e2e.ext.mime.types.HeaderValue;
+
+
+/**
+ * @typedef {{header: !e2e.ext.mime.types.Header,
+ *     body: (string|!Array.<e2e.ext.mime.types.Entity>)}}
+ */
+e2e.ext.mime.types.Entity;

--- a/src/javascript/crypto/e2e/extension/mime/utils.js
+++ b/src/javascript/crypto/e2e/extension/mime/utils.js
@@ -1,0 +1,322 @@
+/**
+ * @license
+ * Copyright 2014 Google Inc. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Helper utils for building/parsing PGP/MIME emails.
+ * @author yzhu@yahoo-inc.com (Yan Zhu)
+ */
+
+goog.provide('e2e.ext.mime.utils');
+
+goog.require('e2e.error.UnsupportedError');
+goog.require('e2e.ext.constants.Mime');
+goog.require('goog.array');
+goog.require('goog.crypt.base64');
+goog.require('goog.object');
+goog.require('goog.string');
+
+goog.scope(function() {
+var ext = e2e.ext;
+var constants = e2e.ext.constants;
+var utils = e2e.ext.mime.utils;
+
+
+/**
+ * Extracts the encrypted MIME tree out of PGP/MIME email text.
+ * @param {string} text The text to parse.
+ * @return {string}
+ */
+ext.mime.utils.getEncryptedMimeTree = function(text) {
+  var rootNode = utils.parseNode_(text);
+  var ctHeader = rootNode.header[constants.Mime.CONTENT_TYPE];
+
+  if (ctHeader.value !== constants.Mime.MULTIPART_ENCRYPTED ||
+      !ctHeader.params ||
+      ctHeader.params.protocol !== constants.Mime.ENCRYPTED ||
+      !goog.isArray(rootNode.body)) {
+    // This does not appear to be a valid PGP encrypted MIME message.
+    utils.fail_(text);
+  } else {
+    // Next node is the required 'application/pgp-encrypted' version node.
+    var middleNode = rootNode.body[0];
+    var contentNode = rootNode.body[1];
+
+    if (middleNode.header[constants.Mime.CONTENT_TYPE].value !==
+        constants.Mime.ENCRYPTED ||
+        contentNode.header[constants.Mime.CONTENT_TYPE].value !==
+        constants.Mime.OCTET_STREAM ||
+        !goog.isString(contentNode.body) ||
+        !goog.isString(middleNode.body)) {
+      utils.fail_(text);
+    }
+    // Next node is the actual encrypted content.
+    return contentNode.body;
+  }
+};
+
+
+/**
+ * Extracts mail content out of a plaintext MIME tree.
+ * @param {string} text The text to parse
+ * @return {e2e.ext.mime.types.MailContent}
+ */
+ext.mime.utils.getMailContent = function(text) {
+  var mailContent = {};
+  var rootNode = utils.parseNode_(text);
+  var ctHeader = rootNode.header[constants.Mime.CONTENT_TYPE];
+
+  // Case 1: Single plaintext node.
+  if (ctHeader.value === constants.Mime.PLAINTEXT &&
+      goog.isString(rootNode.body)) {
+    mailContent.body = rootNode.body;
+    return mailContent;
+  }
+
+  // Case 2: Multipart node
+  if (ctHeader.value === constants.Mime.MULTIPART_MIXED &&
+      goog.isArray(rootNode.body)) {
+    mailContent.attachments = [];
+
+    goog.array.forEach(rootNode.body, goog.bind(function(node) {
+      var ct = node.header[constants.Mime.CONTENT_TYPE].value;
+      if (!goog.isString(node.body) || !ct) {
+        utils.fail_(JSON.stringify(node));
+      }
+      if (ct === constants.Mime.PLAINTEXT) {
+        var text = node.body;
+        mailContent.body = mailContent.body ?
+            utils.joinLines_([mailContent.body, text]) :
+            text;
+      } else if (ct === constants.Mime.OCTET_STREAM) {
+        try {
+          mailContent.attachments.push(
+              utils.parseAttachmentEntity_(node));
+        } catch (e) {}
+      }
+    }, this));
+
+    return mailContent;
+  }
+
+  // If neither Case 1 or 2, MIME tree is unsupported.
+  utils.fail_();
+};
+
+
+/**
+ * Extract attachment content from an attachment node.
+ * @param {e2e.ext.mime.types.Entity} node
+ * @return {e2e.ext.mime.types.Attachment}
+ * @private
+ */
+ext.mime.utils.parseAttachmentEntity_ = function(node) {
+  var filename;
+  var base64 = false;
+
+  try {
+    base64 = (node.header[constants.Mime.CONTENT_TRANSFER_ENCODING].value ===
+              constants.Mime.BASE64);
+    filename = node.header[constants.Mime.CONTENT_DISPOSITION].params.filename;
+  } catch (e) {
+    utils.fail_();
+  }
+
+  if (!base64 || !filename || !goog.isString(node.body)) {
+    utils.fail_();
+  }
+
+  return {filename: filename,
+    content: goog.crypt.base64.decodeStringToByteArray(node.body)};
+};
+
+
+/**
+ * Parses a header value string. Ex: 'multipart/mixed; boundary="foo"'
+ * @param {string} text The string to parse
+ * @return {e2e.ext.mime.types.HeaderValue}
+ */
+ext.mime.utils.parseHeaderValue = function(text) {
+  var parts = text.split('; ');
+  var firstPart = parts.shift();
+
+  // Normalize value to lowercase since it's case insensitive
+  var value = goog.string.stripQuotes(firstPart.toLowerCase().trim(),
+                                      '"');
+
+  var params = {};
+  goog.array.forEach(parts, goog.bind(function(part) {
+    // Ex: 'protocol=application/pgp-encrypted'
+    var paramParts = part.split('=');
+    if (paramParts.length < 2) {
+      return;
+    }
+    // Parameter names are case insensitive acc. to RFC 2045.
+    var paramName = paramParts.shift().toLowerCase().trim();
+    params[paramName] = goog.string.stripQuotes(
+        paramParts.join('=').trim(), '"');
+  }, this));
+
+  return {value: value, params: params};
+};
+
+
+/**
+ * Serialize a header into an array of strings.
+ * @param {e2e.ext.mime.types.Header} header The header to serialize
+ * @return {Array.<string>}
+ */
+ext.mime.utils.serializeHeader = function(header) {
+  var lines = [];
+  goog.object.forEach(header, function(headerValue, headerName) {
+    var line = [headerName + ': ' + headerValue.value];
+    goog.object.forEach(headerValue.params, function(paramValue, paramName) {
+      line.push(paramName + '=' + goog.string.quote(paramValue));
+    });
+    lines.push(line.join('; '));
+  });
+  return lines;
+};
+
+
+/**
+ * Parses MIME headers into a dict, optionally extending existing headers.
+ * @param {string} text The MIME-formatted header.
+ * @return {e2e.ext.mime.types.Header}
+ * @private
+ */
+ext.mime.utils.parseHeader_ = function(text) {
+  var parsed = {};
+
+  // Implicit content-type is ASCII plaintext (RFC 2045)
+  goog.object.setIfUndefined(parsed, constants.Mime.CONTENT_TYPE, {
+    value: constants.Mime.PLAINTEXT,
+    params: {charset: constants.Mime.ASCII}
+  });
+  // Implicit content-transfer-encoding is 7bit (RFC 2045)
+  goog.object.setIfUndefined(parsed, constants.Mime.CONTENT_TRANSFER_ENCODING, {
+    value: constants.Mime.SEVEN_BIT
+  });
+
+  var headerLines = utils.splitLines_(text);
+  goog.array.forEach(headerLines, goog.bind(function(line) {
+    // Ex: 'Content-Type: multipart/encrypted'
+    var parts = line.split(':');
+    if (parts.length < 2) {
+      return;
+    }
+
+    // Header names are not case sensitive. Normalize to TitleCase.
+    var name = goog.string.toTitleCase(parts.shift(), '-');
+    var value = utils.parseHeaderValue(parts.join(':'));
+    parsed[name] = value;
+  }, this));
+  return parsed;
+};
+
+
+/**
+ * Handle failure to parse MIME content.
+ * @param {string=} opt_message The content that was not parseable
+ * @private
+ */
+ext.mime.utils.fail_ = function(opt_message) {
+  var message = opt_message || '';
+  throw new e2e.error.UnsupportedError('Unsupported MIME content: ' + message);
+};
+
+
+/**
+ * Splits a MIME message into lines.
+ * @param {string} text The message to split
+ * @return {Array.<string>}
+ * @private
+ */
+ext.mime.utils.splitLines_ = function(text) {
+  return text.split(constants.Mime.CRLF);
+};
+
+
+/**
+ * Joins a split MIME message.
+ * @param {Array.<string>} lines The lines to join
+ * @return {string}
+ * @private
+ */
+ext.mime.utils.joinLines_ = function(lines) {
+  return lines.join(constants.Mime.CRLF);
+};
+
+
+/**
+ * Splits a MIME message into nodes separated by the MIME boundary ignoring
+ *   all lines after the end boundary.
+ * @param {string} text The message to split.
+ * @param {string} boundary The boundary parameter, as specified in the MIME
+ *   header
+ * @return {Array.<string>}
+ * @private
+ */
+ext.mime.utils.splitNodes_ = function(text, boundary) {
+  var lines = utils.splitLines_(text);
+  var startLocation = goog.array.indexOf(lines, '--' + boundary);
+  var endLocation = goog.array.indexOf(lines, '--' + boundary + '--');
+  if (endLocation === -1 || startLocation === -1) {
+    utils.fail_(text);
+  }
+  // Ignore the epilogue after the end boundary inclusive.
+  lines = goog.array.slice(lines, 0, endLocation);
+  // Ignore the preamble before the first boundary occurrence inclusive.
+  lines = goog.array.slice(lines, startLocation + 1);
+
+  text = utils.joinLines_(lines);
+  return text.split('--' + boundary + constants.Mime.CRLF);
+};
+
+
+/**
+ * Parses a MIME node into a header and body. For multipart messages,
+ *   the body is an array of child nodes. Otherwise body is a string.
+ * @param {string} text The text to parse.
+ * @return {!e2e.ext.mime.types.Entity}
+ * @private
+ */
+ext.mime.utils.parseNode_ = function(text) {
+  // Normalize text by prepending with newline
+  text = constants.Mime.CRLF + text;
+  // Header must be separated from body by an empty line
+  var parts = text.split(constants.Mime.CRLF + constants.Mime.CRLF);
+  if (parts.length < 2) {
+    utils.fail_(text);
+  }
+
+  var header = utils.parseHeader_(parts.shift());
+  var body = parts.join(constants.Mime.CRLF + constants.Mime.CRLF);
+  var ctHeader = header[constants.Mime.CONTENT_TYPE];
+  var parsed = {};
+  parsed.header = header;
+
+  if (ctHeader.params && ctHeader.params.boundary) {
+    // This appears to be a multipart message. Split text by boundary.
+    var nodes = utils.splitNodes_(body, ctHeader.params.boundary);
+    // Recursively parse nodes
+    parsed.body = goog.array.map(nodes, utils.parseNode_);
+  } else {
+    parsed.body = body;
+  }
+  return parsed;
+};
+
+});  // goog.scope

--- a/src/javascript/crypto/e2e/extension/mime/utils_test.html
+++ b/src/javascript/crypto/e2e/extension/mime/utils_test.html
@@ -1,0 +1,25 @@
+<!-- Copyright 2013 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -->
+<!DOCTYPE html>
+<html>
+<head>
+<title>Unit Test of e2e.ext.mime.utils</title>
+<script src="../../../../../../javascript/closure/base.js"></script>
+<script src="test_js_deps-runfiles.js"></script>
+<script>
+  goog.require('e2e.ext.mime.utilsTest');
+</script>
+</head>
+</html>

--- a/src/javascript/crypto/e2e/extension/mime/utils_test.js
+++ b/src/javascript/crypto/e2e/extension/mime/utils_test.js
@@ -1,0 +1,154 @@
+/**
+ * @license
+ * Copyright 2014 Google Inc. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Tests for the PGP/MIME email builder.
+ */
+
+/** @suppress {extraProvide} */
+goog.provide('e2e.ext.mime.utilsTest');
+
+goog.require('e2e.ext.mime.utils');
+goog.require('e2e.ext.testingstubs');
+goog.require('goog.array');
+goog.require('goog.testing.PropertyReplacer');
+goog.require('goog.testing.asserts');
+goog.require('goog.testing.jsunit');
+goog.setTestOnly();
+
+var utils = e2e.ext.mime.utils;
+var stubs = new goog.testing.PropertyReplacer();
+
+
+var PLAINTEXT_MESSAGE = ['From: Nathaniel Borenstein <nsb@bellcore.com>',
+  'To:  Ned Freed <ned@innosoft.com>',
+  'Subject: Sample message',
+  'MIME-Version: 1.0',
+  'Content-type: multipart/mixed; boundary="simple boundary"',
+  '',
+  'This is the preamble.  It is to be ignored, though it',
+  'is a handy place for mail composers to include an',
+  '',
+  'explanatory note to non-MIME compliant readers.',
+  '--simple boundary',
+  '',
+  'This is implicitly typed plain ASCII text.',
+  '',
+  'It does NOT end with a linebreak.',
+  '--simple boundary',
+  'Content-type: text/plain; charset=us-ascii',
+  '',
+  'This is explicitly typed plain ASCII text.',
+  'It DOES end with a linebreak.',
+  '',
+  '--simple boundary',
+  'Content-type: application/octet-stream',
+  'Content-Transfer-Encoding: base64',
+  'Content-Disposition: attachment; filename="foo.txt"',
+  '',
+  'aGVsbG8gd29ybGQK',
+  '--simple boundary--',
+  'This is the epilogue.  It is also to be ignored.'].join('\r\n');
+
+var PLAINTEXT_BODY = ['This is implicitly typed plain ASCII text.',
+  '',
+  'It does NOT end with a linebreak.',
+  '',
+  'This is explicitly typed plain ASCII text.',
+  'It DOES end with a linebreak.',
+  '',
+  ''].join('\r\n');
+
+
+function setUp() {
+  e2e.ext.testingstubs.initStubs(stubs);
+}
+
+
+function tearDown() {
+  stubs.reset();
+}
+
+
+function testGetMultipartMailContent() {
+  var content = goog.array.map('hello world\n'.split(''), function(str) {
+    return str.charCodeAt(0);
+  });
+  var finalContent = {body: PLAINTEXT_BODY,
+    attachments: [{filename: 'foo.txt', content: content}]};
+
+  assertObjectEquals(finalContent, utils.getMailContent(PLAINTEXT_MESSAGE));
+}
+
+
+function testGetInvalidMailContent() {
+  var message = ['Content-Type: multipart/mixed',
+    '',
+    'some text'].join('\r\n');
+  assertThrows('Invalid MIME message should throw unsupported error',
+               function() {
+                 utils.getMailContent(message);
+               });
+}
+
+
+function testGetSinglePartMailContent() {
+  var content = 'some\r\n\r\ntext';
+  var message = ['Content-Type: text/plain; charset=us-ascii',
+    '', content].join('\r\n');
+  assertObjectEquals({body: content}, utils.getMailContent(message));
+}
+
+
+function testGetValidEncryptedMImeTree() {
+  var encryptedText = 'some text';
+  var message = ['Content-Type: multipart/encrypted; ' +
+        'protocol=application/pgp-encrypted; boundary="--foo"',
+    'Content-Transfer-Encoding: 7bit', '', '----foo',
+    'Content-Type: application/pgp-encrypted; charset="utf-8"',
+    'Content-Transfer-Encoding: 7bit', '', 'Version: 1', '----foo',
+    'Content-Type: application/octet-stream; charset="utf-8"',
+    'Content-Transfer-Encoding: 7bit', '', encryptedText,
+    '----foo--', ''].join('\r\n');
+  assertEquals(encryptedText, utils.getEncryptedMimeTree(message));
+}
+
+
+function testGetInvalidEncryptedMimeTree() {
+  assertThrows('Non-PGP/MIME message should throw unsupported error',
+               function() {
+                 utils.getEncryptedMimeTree(PLAINTEXT_MESSAGE);
+               });
+}
+
+
+function testParseHeaderValue() {
+  var text = 'MULTIPART/mixed;   BOUNDARY=" foo=";  bar=somevalue';
+  assertObjectEquals({value: 'multipart/mixed', params: {
+    boundary: ' foo=',
+    bar: 'somevalue'
+  }}, utils.parseHeaderValue(text));
+}
+
+
+function testSerializeHeader() {
+  var header = {'Content-Type': {value: 'multipart', params: {
+    charset: 'us-ascii',
+    foo: 'bar='
+  }}, 'Content-Transfer-Encoding': {value: '7bit'}};
+  assertArrayEquals(['Content-Type: multipart; charset="us-ascii"; foo="bar="',
+    'Content-Transfer-Encoding: 7bit'], utils.serializeHeader(header));
+}


### PR DESCRIPTION
Adds a message builder and parser for PGP/MIME (RFC 2045 and RFC 3156) messages. Note that this doesn't support the majority of MIME types but should provide the minimum needed for PGP/MIME.

In theory, most mail clients that support PGP/MIME should be able to parse the output of `mime.PgpMail.prototype.buildSignedAndEncrypted ` correctly as long as {g,y}mail's native MIME message builders don't mangle it too badly. I haven't yet tested this in practice.