### PR TITLE
Add API method to list all UIDs in keyring.

### DIFF
--- a/src/javascript/crypto/e2e/extension/actions/listalluids.js
+++ b/src/javascript/crypto/e2e/extension/actions/listalluids.js
@@ -1,0 +1,61 @@
+/**
+ * @license
+ * Copyright 2014 Google Inc. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Lists all public or private keys (never both) in the extension.
+ */
+
+goog.provide('e2e.ext.actions.ListAllUids');
+
+goog.require('e2e.ext.actions.Action');
+goog.require('goog.array');
+
+goog.scope(function() {
+var actions = e2e.ext.actions;
+
+
+
+/**
+ * Constructor for the action.
+ * @constructor
+ * @implements {e2e.ext.actions.Action.<string, !Array>}
+ */
+actions.ListAllUids = function() {};
+
+
+/** @inheritDoc */
+actions.ListAllUids.prototype.execute =
+    function(ctx, request, requestor, callback, errorCallback) {
+  ctx.getAllKeys(request.content === 'private').
+      addCallback(function(result) {
+        var uids = [];
+        var getUidsFromKey = function(key) {
+          if (key && key.uids) {
+            goog.array.extend(uids, key.uids);
+          }
+        };
+        for (var keyId in result) {
+          if (result.hasOwnProperty(keyId)) {
+            var keys = result[keyId];
+            goog.array.forEach(keys, getUidsFromKey);
+          }
+        }
+        callback(uids);
+      }).
+      addErrback(errorCallback);
+};
+
+});  // goog.scope

--- a/src/javascript/crypto/e2e/extension/actions/listalluids_test.html
+++ b/src/javascript/crypto/e2e/extension/actions/listalluids_test.html
@@ -1,0 +1,25 @@
+<!-- Copyright 2014 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -->
+<!DOCTYPE html>
+<html>
+<head>
+<title>Unit Test of e2e.ext.actions.ListAllUids</title>
+<script src="../../../../../../javascript/closure/base.js"></script>
+<script src="test_js_deps-runfiles.js"></script>
+<script>
+  goog.require('e2e.ext.actions.ListAllUidsTest');
+</script>
+</head>
+</html>

--- a/src/javascript/crypto/e2e/extension/actions/listalluids_test.js
+++ b/src/javascript/crypto/e2e/extension/actions/listalluids_test.js
@@ -1,0 +1,205 @@
+/**
+ * @license
+ * Copyright 2014 Google Inc. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Tests for the LIST_ALL_UIDS action.
+ */
+
+/** @suppress {extraProvide} */
+goog.provide('e2e.ext.actions.ListAllUidsTest');
+
+goog.require('e2e.ext.actions.ListAllUids');
+goog.require('e2e.ext.testingstubs');
+goog.require('e2e.openpgp.ContextImpl');
+goog.require('goog.array');
+goog.require('goog.testing.AsyncTestCase');
+goog.require('goog.testing.MockControl');
+goog.require('goog.testing.PropertyReplacer');
+goog.require('goog.testing.asserts');
+goog.require('goog.testing.jsunit');
+goog.require('goog.testing.mockmatchers');
+goog.require('goog.testing.mockmatchers.ArgumentMatcher');
+goog.setTestOnly();
+
+var mockControl = null;
+var stubs = new goog.testing.PropertyReplacer();
+var testCase = goog.testing.AsyncTestCase.createAndInstall(document.title);
+
+var USER_ID = 'test 4';
+var USER_ID_2 = 'Drew Hintz <adhintz@google.com>';
+
+var PRIVATE_KEY_ASCII =
+    '-----BEGIN PGP PRIVATE KEY BLOCK-----\n' +
+    'Version: GnuPG v1.4.11 (GNU/Linux)\n' +
+    '\n' +
+    'lQIGBFHMug4BBACW9E+4EJXykFpkdHS1K7nkTFcvFHpnJsbHSB99Px6ib6jusVNJ\n' +
+    'SjWhbWlcQXXpwDKRKKItRHE4v2zin89+hWPxQEU4l79S17i8xSXT8o02I4e7cPrj\n' +
+    'j1JSyQk2YpIK5zNO7cU1IlVRHrTmvrp8ip9exF9D5UqQGxmXncjtJxsF8wARAQAB\n' +
+    '/gkDAgxGSvTcN/9nYDs6DJVcH5zs/RiEw8xwMhVxHepb0D0jHDxWpPxHoT6enWSS\n' +
+    'expqlvP6Oclgp0AgUBZNLr1G8i6cFTbH8VP1f+be3isyt/DzBYUE3GEBj/6pg2ft\n' +
+    'tRgUs/yWT731BkvK6o3kMBm5OJtOSi6rBwvNgfgA3KLlv4QknOHAFoEZL+CpsjWn\n' +
+    'SPE7SdAPIcIiT4aIrIe4RWm0iP1HcCfhoGgvbMlrB9r5uQdlenRxWwhP+Tlik5A9\n' +
+    'uYqrAT4Rxb7ce+IDuWPHGOZVIQr4trXegGpCHqfi0DgZ0MOolaSnfcrRDZMy0zAd\n' +
+    'HASBijOSPTZiF1aSg/p6ghqBvDwRvRgLv1HNdaObH+LRpr/AI/t0o6AmqWdeuLIG\n' +
+    'TctvYIIEZNvThDvYzjcpoxz03qRD3I+b8nuyweKH/2bUSobHc6EacHYSUML8SxRC\n' +
+    'TcM/iyDcplK5g1Rul73fhAjw3A9Y6elGiitzmO/oeAi2+Oh7XrUdnaG0BnRlc3Qg\n' +
+    'NIi4BBMBAgAiBQJRzLoOAhsDBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAKCRAG\n' +
+    '/5ysCS2oCL2SA/9EV9j3T/TM3VRD0NvNySHodcxCP1BF0zm/M84I/WHQsGKmHStf\n' +
+    'CqqEGruB8E6NHQMJwNp1TzcswuxE0wiTJiXKe3w3+GZhPHdW5zcgiMKKYLn80Tk6\n' +
+    'fUMx1zVZtXlSBYCN5Op/axjQRyb+fGnXOhmboqQodYaWS7qhJWQJilH6ip0CBgRR\n' +
+    'zLoOAQQAw0zLIR7cmIS5lgu+/dxZThZebZHBH3RSiUZt9JP/cpMuHLs//13uLlzO\n' +
+    '9kmkyNQ34ulCM+WbhU8cN25wF2r/kleEOHWaNIW+I1PGGkHwy+E7Eae7juoqsXfJ\n' +
+    '5bIfSZwShOhZPwluRaDGWd/8hJt6avduFL9gGZTunWn4F3nMqjUAEQEAAf4JAwIM\n' +
+    'Rkr03Df/Z2BQOTPSVVkZoaZ2FC7fly+54YG9jWBCAwR6P8Os8Cp1BM8BG+E6jL3b\n' +
+    'X7djq70YwF9t1NMas2sXviGfAZEpZZnjQYfcl6EsvBciDspzYQKiSdndCehuoA4g\n' +
+    'QYJ0M9XzBtCaCJ7ti2azTNAYYtw0vWkvGfgzWxw6IbLttHRIWEdvBMul+u2NzPhy\n' +
+    'x8MpulrIyAER0SgaE0oJlHm8LfjV/qJd4Gpb9NG9QmdFrpPrIvDFh/mJC6CyqdVU\n' +
+    'ZfahmuzfFANMEZehsrFHZmpIAzfrv5BBppVV4/vVVuoR74ohcur36sqiSZPI4pkg\n' +
+    'LE7BR0A4PGdSRroZZFB4djV+6dIM0LKwqb+d50UUsJy7JIyIFHZAR70tEIfyyF0I\n' +
+    '7ZzlmO9ebwy/XiJnxYuVKh3M1q97b7lGlVGD4hvi37jv+YYqLe4Rd4T9Ho+qM33T\n' +
+    'OfVHAfr6v5YhlnaMYfKC7407kWA9bRnItdjy/m5br05bncH7iJ8EGAECAAkFAlHM\n' +
+    'ug4CGwwACgkQBv+crAktqAhENwQAkMY/nds36KgzwfMPpxtBaq8GbrUqY1r8lBl6\n' +
+    'a/bi8qeOuEgQmIxM2OpVPtL04c1c1hLflPCi1SQUlCIh3DkEGQIcy0/wxUZdCvZK\n' +
+    '0mF5nZSq6tez3CwqbeOA4nBOLwbxho50VqxBpR4qypYrB2ipykxlwiqudEe0sE2b\n' +
+    '1KwNtVw=\n' +
+    '=wHzz\n' +
+    '-----END PGP PRIVATE KEY BLOCK-----';
+
+var PUBLIC_KEY_ASCII =
+    '-----BEGIN PGP PUBLIC KEY BLOCK-----\n' +
+    'Version: GnuPG v1.4.11 (GNU/Linux)\n' +
+    '\n' +
+    'mI0EUcy6DgEEAJb0T7gQlfKQWmR0dLUrueRMVy8UemcmxsdIH30/HqJvqO6xU0lK\n' +
+    'NaFtaVxBdenAMpEooi1EcTi/bOKfz36FY/FARTiXv1LXuLzFJdPyjTYjh7tw+uOP\n' +
+    'UlLJCTZikgrnM07txTUiVVEetOa+unyKn17EX0PlSpAbGZedyO0nGwXzABEBAAG0\n' +
+    'BnRlc3QgNIi4BBMBAgAiBQJRzLoOAhsDBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIX\n' +
+    'gAAKCRAG/5ysCS2oCL2SA/9EV9j3T/TM3VRD0NvNySHodcxCP1BF0zm/M84I/WHQ\n' +
+    'sGKmHStfCqqEGruB8E6NHQMJwNp1TzcswuxE0wiTJiXKe3w3+GZhPHdW5zcgiMKK\n' +
+    'YLn80Tk6fUMx1zVZtXlSBYCN5Op/axjQRyb+fGnXOhmboqQodYaWS7qhJWQJilH6\n' +
+    'iriNBFHMug4BBADDTMshHtyYhLmWC7793FlOFl5tkcEfdFKJRm30k/9yky4cuz//\n' +
+    'Xe4uXM72SaTI1Dfi6UIz5ZuFTxw3bnAXav+SV4Q4dZo0hb4jU8YaQfDL4TsRp7uO\n' +
+    '6iqxd8nlsh9JnBKE6Fk/CW5FoMZZ3/yEm3pq924Uv2AZlO6dafgXecyqNQARAQAB\n' +
+    'iJ8EGAECAAkFAlHMug4CGwwACgkQBv+crAktqAhENwQAkMY/nds36KgzwfMPpxtB\n' +
+    'aq8GbrUqY1r8lBl6a/bi8qeOuEgQmIxM2OpVPtL04c1c1hLflPCi1SQUlCIh3DkE\n' +
+    'GQIcy0/wxUZdCvZK0mF5nZSq6tez3CwqbeOA4nBOLwbxho50VqxBpR4qypYrB2ip\n' +
+    'ykxlwiqudEe0sE2b1KwNtVw=\n' +
+    '=nHBL\n' +
+    '-----END PGP PUBLIC KEY BLOCK-----';
+
+var PUBLIC_KEY_ASCII_2 =  // user ID of 'Drew Hintz <adhintz@google.com>'
+    '-----BEGIN PGP PUBLIC KEY BLOCK-----\n' +
+    'Charset: UTF-8\n' +
+    '\n' +
+    'xv8AAABSBFP3bHYTCCqGSM49AwEHAgMECt6MVqa43Ab248CosK/cy664pkL/9XvC\n' +
+    '0O2K0O1Jh2qau7ll3Q9vssdObSwX0EaiMm4Dvegxr1z+SblWSFV4x83/AAAAH0Ry\n' +
+    'ZXcgSGludHogPGFkaGludHpAZ29vZ2xlLmNvbT7C/wAAAGYEEBMIABj/AAAABYJT\n' +
+    '92x2/wAAAAmQ8eznwfj7hkMAADA9AQCWE4jmpmA5XRN1tZduuz8QwtxGZOFurpAK\n' +
+    '6RCzKDqS8wEAx9eBxXLhKB4xm9xwPdh0+W6rbsvf58FzKjlxrkUfuxTO/wAAAFYE\n' +
+    'U/dsdhIIKoZIzj0DAQcCAwQ0M6kFa7VaVmt2PRdOUdZWrHp6CZZglTVQi1eyiXB/\n' +
+    'nnUUbH+qrreWTD7W9RxRtr0IqAYssLG5ZoWsXa5jQC3DAwEIB8L/AAAAZgQYEwgA\n' +
+    'GP8AAAAFglP3bHf/AAAACZDx7OfB+PuGQwAAkO4BALMuXsta+bCOvzSn7InOs7wA\n' +
+    '+OmDN5cv1cR/SsN5+FkLAQCmmBa/Fe76gmDd0RjvpQW7pWK2zXj3il6HYQ2NsWlI\n' +
+    'bQ==\n' +
+    '=LlKd\n' +
+    '-----END PGP PUBLIC KEY BLOCK-----';
+
+
+function setUp() {
+  window.localStorage.clear();
+  mockControl = new goog.testing.MockControl();
+  e2e.ext.testingstubs.initStubs(stubs);
+}
+
+
+function tearDown() {
+  stubs.reset();
+  mockControl.$tearDown();
+}
+
+
+function testExecuteEmpty() {
+  var pgpContext = new e2e.openpgp.ContextImpl();
+  pgpContext.setKeyRingPassphrase(''); // No passphrase.
+
+  var errorCallback = mockControl.createFunctionMock('errorCallback');
+  errorCallback(goog.testing.mockmatchers.ignoreArgument);
+
+  var callback = function(result) {
+    assertArrayEquals([], result);
+  };
+
+  var action = new e2e.ext.actions.ListAllUids();
+
+  mockControl.$replayAll();
+  action.execute(pgpContext, {
+    content: 'private'
+  }, null, callback, errorCallback);
+}
+
+
+function testExecutePublicKeys() {
+  var pgpContext = new e2e.openpgp.ContextImpl();
+  pgpContext.setKeyRingPassphrase(''); // No passphrase.
+
+  var errorCallback = mockControl.createFunctionMock('errorCallback');
+  var callback = mockControl.createFunctionMock('callback');
+  callback(new goog.testing.mockmatchers.ArgumentMatcher(function(arg) {
+    return (goog.array.contains(arg, USER_ID) &&
+            goog.array.contains(arg, USER_ID_2));
+  }));
+
+  var action = new e2e.ext.actions.ListAllUids();
+
+  mockControl.$replayAll();
+  testCase.waitForAsync('Waiting for keys to be populated.');
+  pgpContext.importKey(goog.nullFunction, PUBLIC_KEY_ASCII).
+      addCallback(function() {
+        pgpContext.importKey(goog.nullFunction, PUBLIC_KEY_ASCII_2).
+            addCallback(function() {
+              action.execute(pgpContext, {
+                content: 'public'
+              }, null, callback, errorCallback);
+              mockControl.$verifyAll();
+              testCase.continueTesting();
+            });
+      });
+}
+
+
+function testExecutePrivateKeys() {
+  var pgpContext = new e2e.openpgp.ContextImpl();
+  pgpContext.setKeyRingPassphrase(''); // No passphrase.
+
+  var errorCallback = mockControl.createFunctionMock('errorCallback');
+  var callback = mockControl.createFunctionMock('callback');
+  callback(new goog.testing.mockmatchers.ArgumentMatcher(function(arg) {
+    return goog.array.contains(arg, USER_ID);
+  }));
+
+  var action = new e2e.ext.actions.ListAllUids();
+
+  mockControl.$replayAll();
+  testCase.waitForAsync('Waiting for keys to be populated.');
+  pgpContext.importKey(function(uid, callback) {
+    callback('test');
+  }, PRIVATE_KEY_ASCII).addCallback(function() {
+    action.execute(pgpContext, {
+      content: 'private'
+    }, null, callback, errorCallback);
+    mockControl.$verifyAll();
+    testCase.continueTesting();
+  });
+}

--- a/src/javascript/crypto/e2e/extension/api/api.js
+++ b/src/javascript/crypto/e2e/extension/api/api.js
@@ -132,6 +132,7 @@ api.Api.prototype.executeAction_ = function(callback, req) {
   switch (incoming.action) {
     case constants.Actions.ENCRYPT_SIGN:
     case constants.Actions.DECRYPT_VERIFY:
+    case constants.Actions.LIST_ALL_UIDS:
       // Propagate the decryptPassphrase if needed.
       incoming.passphraseCallback = function(uid, passphraseCallback) {
         if (incoming.decryptPassphrase) {

--- a/src/javascript/crypto/e2e/extension/constants.js
+++ b/src/javascript/crypto/e2e/extension/constants.js
@@ -46,6 +46,7 @@ e2e.ext.constants.Actions = {
   RESTORE_KEYRING_DATA: 'restore_keyring_data',
   IMPORT_KEY: 'import_key',
   LIST_KEYS: 'list_keys',
+  LIST_ALL_UIDS: 'list_all_uids',
 
   // Intended no-op. Used for closing the prompt UI when other visual elements
   // (e.g. looking glass) would display data.


### PR DESCRIPTION
Proposal: Expose an API method to content scripts to get a list of all the UIDs in the keyring. This is used already in Yahoo mail to change the native appearance of email address "chips" if there is a public key for a recipient address or a private key for the sender address. IMO this should eventually be supported in the website API.
