### PR TITLE
Add P521 to performance tests.

### DIFF
--- a/src/javascript/crypto/e2e/ecc/domainparam.js
+++ b/src/javascript/crypto/e2e/ecc/domainparam.js
@@ -162,6 +162,7 @@ e2e.ecc.DomainParam.fromCurve = function(curveName) {
   switch (curveName) {
     case e2e.ecc.PrimeCurve.P_256:
     case e2e.ecc.PrimeCurve.P_384:
+    case e2e.ecc.PrimeCurve.P_521:
       result = e2e.ecc.DomainParam.NIST.fromCurve(curveName);
       break;
     case e2e.ecc.PrimeCurve.CURVE_25519:

--- a/src/javascript/crypto/e2e/ecc/ecc_perf_test.html
+++ b/src/javascript/crypto/e2e/ecc/ecc_perf_test.html
@@ -43,6 +43,11 @@ function testP834() {
     e2e.ecc.PrimeCurve.P_384);
 }
 
+function testP521() {
+  e2e.ecc.eccTester.runBenchmarkForCurve(
+    e2e.ecc.PrimeCurve.P_521);
+}
+
 </script>
 </body>
 </html>


### PR DESCRIPTION
src/javascript/crypto/e2e/ecc/domainparam.js: Added P_521 to the set of recognized curves in e2e.ecc.DomainParam.fromCurve

src/javascript/crypto/e2e/ecc/ecc_perf_test.html:
Added a testP521 function.

As a note:

```
P_521 Fast Multiply 10   20 2 17  22
P_521 Slow Multiply 10   79 5 74  88
P_521 Bignum        10    1 0  1   2
P_521 Sign          10   21 1 19  24
P_521 Verify        10   97 5 93 110

P_384 Fast Multiply 10   18 1 16  20
P_384 Slow Multiply 10   76 4 72  83
P_384 Bignum modInv 10    1 1  1   2
P_384 Sign          10   20 0 20  21
P_384 Verify        10   93 3 90 101
```
