### PR TITLE
Generate keys on P384 by default.

### DIFF
--- a/src/javascript/crypto/e2e/openpgp/keygenerator.js
+++ b/src/javascript/crypto/e2e/openpgp/keygenerator.js
@@ -34,7 +34,7 @@ goog.require('goog.crypt.base64');
 
 
 /**
- * Generates a key pair on the default curve and uses it to construct
+ * Generates a key pair on secp256r1 and uses it to construct
  * an ECDSA object.
  * @param {!e2e.ByteArray=} opt_privateKey  An optional already known
  *     private key. If not given, a random key will be created.
@@ -49,7 +49,7 @@ e2e.openpgp.keygenerator.newEcdsaWithP256 = function(
 
 
 /**
- * Generates a key pair on the default curve and uses it to construct
+ * Generates a key pair on secp256r1 and uses it to construct
  * an ECDH object.
  * @param {!e2e.ByteArray=} opt_privateKey  An optional already known
  *     private key. If not given, a random key will be created.
@@ -61,6 +61,38 @@ e2e.openpgp.keygenerator.newEcdhWithP256 = function(
       e2e.ecc.PrimeCurve.P_256, opt_privateKey);
   key['kdfInfo'] = [
     0x3, 0x1, 0x8 /* SHA256 Algo ID*/, 0x7 /* AES-128 Algo ID */];
+  return new e2e.cipher.Ecdh(e2e.cipher.Algorithm.ECDH, key);
+};
+
+
+/**
+ * Generates a key pair on secp384r1 and uses it to construct
+ * an ECDSA object.
+ * @param {!e2e.ByteArray=} opt_privateKey  An optional already known
+ *     private key. If not given, a random key will be created.
+ * @return {!e2e.signer.Ecdsa}
+ */
+e2e.openpgp.keygenerator.newEcdsaWithP384 = function(
+    opt_privateKey) {
+  var key = e2e.ecc.Protocol.generateKeyPair(
+      e2e.ecc.PrimeCurve.P_384, opt_privateKey);
+  return new e2e.signer.Ecdsa(e2e.signer.Algorithm.ECDSA, key);
+};
+
+
+/**
+ * Generates a key pair on secp384r1 and uses it to construct
+ * an ECDH object.
+ * @param {!e2e.ByteArray=} opt_privateKey  An optional already known
+ *     private key. If not given, a random key will be created.
+ * @return {!e2e.cipher.Ecdh}
+ */
+e2e.openpgp.keygenerator.newEcdhWithP384 = function(
+    opt_privateKey) {
+  var key = e2e.ecc.Protocol.generateKeyPair(
+      e2e.ecc.PrimeCurve.P_384, opt_privateKey);
+  key['kdfInfo'] = [
+    0x3, 0x1, 0x9 /* SHA384 Algo ID*/, 0x8 /* AES-256 Algo ID */];
   return new e2e.cipher.Ecdh(e2e.cipher.Algorithm.ECDH, key);
 };
 
@@ -85,7 +117,7 @@ e2e.openpgp.keygenerator.newWebCryptoRsaKeys = function(keyLength) {
   var result = new e2e.async.Result;
   var rsaSigner;
   var rsaCipher;
-  crypto.generateKey(aid, false, ['sign', 'verify']).catch(
+  crypto.generateKey(aid, false, ['sign', 'verify']).catch (
       function(e) {
         result.errback(e);
       }).then(function(sigKeyPair) {
@@ -98,7 +130,7 @@ e2e.openpgp.keygenerator.newWebCryptoRsaKeys = function(keyLength) {
           rsaSigner.setWebCryptoKey(sigKeyPair);
 
           aid.name = 'RSAES-PKCS1-v1_5';
-          crypto.generateKey(aid, false, ['encrypt', 'decrypt']).catch(
+          crypto.generateKey(aid, false, ['encrypt', 'decrypt']).catch (
               function(e) {
                 result.errback(e);
               }).then(function(encKeyPair) {
@@ -113,9 +145,9 @@ e2e.openpgp.keygenerator.newWebCryptoRsaKeys = function(keyLength) {
                   rsaCipher.setWebCryptoKey(encKeyPair);
 
                   result.callback([rsaSigner, rsaCipher]);
-                }).catch(function(e) { result.errback(e); });
+                }).catch (function(e) { result.errback(e); });
           });
-        }).catch(function(e) { result.errback(e); });
+        }).catch (function(e) { result.errback(e); });
   });
   return result;
 };

--- a/src/javascript/crypto/e2e/openpgp/keyring.js
+++ b/src/javascript/crypto/e2e/openpgp/keyring.js
@@ -276,8 +276,8 @@ e2e.openpgp.KeyRing.prototype.importKey = function(
  * The generated public key and secret key in an array.
  */
 e2e.openpgp.KeyRing.prototype.generateECKey = function(email) {
-  return this.generateKey(email, e2e.signer.Algorithm.ECDSA, 256,
-      e2e.cipher.Algorithm.ECDH, 256);
+  return this.generateKey(email, e2e.signer.Algorithm.ECDSA, 384,
+      e2e.cipher.Algorithm.ECDH, 384);
 };
 
 
@@ -340,17 +340,33 @@ e2e.openpgp.KeyRing.prototype.generateKey = function(email,
 
   if (opt_keyLocation == e2e.algorithm.KeyLocations.JAVASCRIPT) {
     var fingerprint;
-    if (keyAlgo == e2e.signer.Algorithm.ECDSA &&
-        keyLength == 256) {
-      var ecdsa = e2e.openpgp.keygenerator.newEcdsaWithP256(
-          this.getNextKey_(keyLength));
+    if (keyAlgo == e2e.signer.Algorithm.ECDSA) {
+      var ecdsa;
+      if (keyLength == 256) {
+        ecdsa = e2e.openpgp.keygenerator.newEcdsaWithP256(
+            this.getNextKey_(keyLength));
+      } else if (keyLength == 384) {
+        ecdsa = e2e.openpgp.keygenerator.newEcdsaWithP384(
+            this.getNextKey_(keyLength));
+      } else {
+        throw new e2e.openpgp.error.UnsupportedError(
+            'Only secp256r1 and secp384r1 supported');
+      }
       this.extractKeyData_(keyData, ecdsa);
       fingerprint = keyData.pubKey[0].fingerprint;
     }
-    if (subkeyAlgo == e2e.cipher.Algorithm.ECDH &&
-        subkeyLength == 256) {
-      var ecdh = e2e.openpgp.keygenerator.newEcdhWithP256(
-          this.getNextKey_(subkeyLength));
+    if (subkeyAlgo == e2e.cipher.Algorithm.ECDH) {
+      var ecdh;
+      if (subkeyLength == 256) {
+        ecdh = e2e.openpgp.keygenerator.newEcdhWithP256(
+            this.getNextKey_(subkeyLength));
+      } else if (subkeyLength == 384) {
+        ecdh = e2e.openpgp.keygenerator.newEcdhWithP384(
+            this.getNextKey_(subkeyLength));
+      } else {
+        throw new e2e.openpgp.error.UnsupportedError(
+            'Only secp256r1 and secp384r1 supported');
+      }
       this.extractKeyData_(keyData, ecdh, true);
     }
     return e2e.async.Result.toResult(this.certifyKeys_(email, keyData));


### PR DESCRIPTION
Rationale: P384 is a larger curve. Performance implications negligible. (At least on our test devices.)

In addition, it satisfies some other (lowish-probability) safety properties, as compared to P256. (E.g., the probability of a random curve having cofactor 1 on the twist is about 2%. P384's twist has cofactor 1, P256's twist has rather large cofactors.)

e2e/openpgp/keygenerator.js: Add newEcdhWithP384() and newEcdsaWithP384() functions.
e2e/openpgp/keyring.js:
  Keyring.generateKey(): Add support for P384.
  generateECKey(): Generate keys on P384 by default.