### PR TITLE
fixing type annotations due to closure compiler changes

### DIFF
--- a/src/javascript/crypto/e2e/compression/factory.js
+++ b/src/javascript/crypto/e2e/compression/factory.js
@@ -36,7 +36,7 @@ e2e.compression.factory.compressionAlgorithms_ = {};
 
 /**
  * Registers a class for a specific algorithm.
- * @param {function(new:e2e.compression.Compression, ...[*])}
+ * @param {function(new:e2e.compression.Compression, ...*)}
  *    compression The constructor of the cipher.
  * @param {e2e.compression.Algorithm=} opt_algorithm The algorithm to
  *     register it to, if different from the prototype name.

--- a/src/javascript/crypto/e2e/hash/factory.js
+++ b/src/javascript/crypto/e2e/hash/factory.js
@@ -36,7 +36,7 @@ e2e.hash.factory.hashes_ = {};
 
 /**
  * Registers a class for a specific algorithm.
- * @param {function(new:e2e.hash.Hash, ...[*])} hash The constructor of
+ * @param {function(new:e2e.hash.Hash, ...*)} hash The constructor of
  *     the cipher.
  * @param {e2e.hash.Algorithm=} opt_algorithm The algorithm to register
  *     it to, if different from the prototype name.


### PR DESCRIPTION
Hi - I work at UW on freedomjs/uProxy (a Google Ideas project) and have been working on incorporating end-to-end into it (https://github.com/freedomjs/freedom-pgp-e2e/). I noticed today that it was no longer compiling, specifically ./do.sh build_library failed with "ERROR - Bad type annotation. type not recognized due to syntax error."

This pull request fixes the annotations so the library compiles again - if you have some other process to get this change in let me know, but for now I figured I'd make the pull request to at least notify the right people. Thanks!