### PR TITLE
Update build reference to extension_manifest.json

### DIFF
--- a/do.sh
+++ b/do.sh
@@ -161,7 +161,7 @@ e2e_build_extension() {
   cp -fr "$SRC_EXT_DIR/_locales" "$BUILD_EXT_DIR"
   find "$SRC_EXT_DIR/ui" -regex .*.html -not -regex .*_test.html -exec cp -f "{}" "$BUILD_EXT_DIR" \;
   cp -f "$SRC_EXT_DIR/helper/gmonkeystub.js" "$BUILD_EXT_DIR"
-  cp -f "$SRC_EXT_DIR/manifest.json" "$BUILD_EXT_DIR"
+  cp -f "$SRC_EXT_DIR/extension_manifest.json" "$BUILD_EXT_DIR/manifest.json"
   echo "Done."
 }
 


### PR DESCRIPTION
When running `./do.sh build_extension` I got the following error:

    cp: src/javascript/crypto/e2e/extension/manifest.json: No such file or directory

Appears to have been broken by b352163ba8a5ac35c61f44ea4ae9d8a8c2eb246f