### PR TITLE
Remove trailing / from closure-library git repo

### DIFF
--- a/download-libs.sh
+++ b/download-libs.sh
@@ -39,7 +39,7 @@ cd lib
 
 # checkout closure library
 if [ ! -d closure-library/.git ]; then
-  git clone --depth 1 https://github.com/google/closure-library/ closure-library
+  git clone --depth 1 https://github.com/google/closure-library closure-library
 fi
 
 # checkout zlib.js

--- a/download-libs.sh
+++ b/download-libs.sh
@@ -54,7 +54,7 @@ if [ ! -d closure-compiler/.git ]; then
   if [ -d closure-compiler ]; then # remove binary release directory
     rm -rf closure-compiler
   fi
-  git clone --depth 1 https://github.com/google/closure-compiler/ closure-compiler
+  git clone --depth 1 https://github.com/google/closure-compiler closure-compiler
 fi
 
 # build closure compiler


### PR DESCRIPTION
Without this change:

    Cloning into 'closure-library'...
    ERROR: Repository not found.

With this change:

    Cloning into 'closure-library'...
    remote: Counting objects: 2589, done.
    remote: Compressing objects: 100% (2002/2002), done.
    ...

