### PR TITLE
Simplify target and build options

### DIFF
--- a/do.sh
+++ b/do.sh
@@ -131,17 +131,17 @@ e2e_build_extension() {
   SRC_DIRS=( src lib/closure-library lib/closure-templates-compiler $BUILD_TPL_DIR \
     lib/zlib.js/src lib/typedarray )
 
+  # compile javascript files
   jscompile_e2e="$JSCOMPILE_CMD"
   for var in "${SRC_DIRS[@]}"
   do
     jscompile_e2e+=" --js='$var/**.js' --js='!$var/**_test.js'"
   done
-  csscompile_e2e="java -jar lib/closure-stylesheets-20111230.jar src/javascript/crypto/e2e/extension/ui/styles/base.css"
-  # compile javascript files
-  echo "Compiling JS files..."
   if [ "$1" == "debug" ]; then
+    echo "Debug mode enabled"
     jscompile_e2e+=" --debug --formatting=PRETTY_PRINT"
   fi
+  echo "Compiling JS files..."
   echo -n "." && $jscompile_e2e --closure_entry_point "e2e.ext.bootstrap" --js_output_file "$BUILD_EXT_DIR/launcher_binary.js"
   echo -n "." && $jscompile_e2e --closure_entry_point "e2e.ext.Helper" --js_output_file "$BUILD_EXT_DIR/helper_binary.js"
   echo -n "." && $jscompile_e2e --closure_entry_point "e2e.ext.ui.glass.bootstrap" --js_output_file "$BUILD_EXT_DIR/glass_binary.js"
@@ -150,6 +150,7 @@ e2e_build_extension() {
   echo -n "." && $jscompile_e2e --closure_entry_point "e2e.ext.ui.Welcome" --js_output_file "$BUILD_EXT_DIR/welcome_binary.js"
   echo ""
   # compile css files
+  csscompile_e2e="java -jar lib/closure-stylesheets-20111230.jar src/javascript/crypto/e2e/extension/ui/styles/base.css"
   echo "Compiling CSS files..."
   $csscompile_e2e "$SRC_EXT_DIR/ui/glass/glass.css" > "$BUILD_EXT_DIR/glass_styles.css"
   $csscompile_e2e "$SRC_EXT_DIR/ui/prompt/prompt.css" > "$BUILD_EXT_DIR/prompt_styles.css"
@@ -179,17 +180,17 @@ e2e_build_app() {
   SRC_DIRS=( src lib/closure-library lib/closure-templates-compiler $BUILD_TPL_DIR \
     lib/zlib.js/src lib/typedarray )
 
+  # compile javascript files
   jscompile_e2e="$JSCOMPILE_CMD"
   for var in "${SRC_DIRS[@]}"
   do
     jscompile_e2e+=" --js='$var/**.js' --js='!$var/**_test.js'"
   done
-  csscompile_e2e="java -jar lib/closure-stylesheets-20111230.jar src/javascript/crypto/e2e/extension/ui/styles/base.css"
-  # compile javascript files
-  echo "Compiling JS files..."
   if [ "$1" == "debug" ]; then
+    echo "Debug mode enabled"
     jscompile_e2e+=" --debug --formatting=PRETTY_PRINT"
   fi
+  echo "Compiling JS files..."
   echo -n "." && $jscompile_e2e --closure_entry_point "e2e.ext.bootstrap" --js_output_file "$BUILD_EXT_DIR/launcher_binary.js"
   echo -n "." && $jscompile_e2e --closure_entry_point "e2e.ext.Helper" --js_output_file "$BUILD_EXT_DIR/helper_binary.js"
   echo -n "." && $jscompile_e2e --closure_entry_point "e2e.ext.ui.glass.bootstrap" --js_output_file "$BUILD_EXT_DIR/glass_binary.js"
@@ -198,6 +199,7 @@ e2e_build_app() {
   echo -n "." && $jscompile_e2e --closure_entry_point "e2e.ext.ui.Welcome" --js_output_file "$BUILD_EXT_DIR/welcome_binary.js"
   echo ""
   # compile css files
+  csscompile_e2e="java -jar lib/closure-stylesheets-20111230.jar src/javascript/crypto/e2e/extension/ui/styles/base.css"
   echo "Compiling CSS files..."
   $csscompile_e2e "$SRC_EXT_DIR/ui/glass/glass.css" > "$BUILD_EXT_DIR/glass_styles.css"
   $csscompile_e2e "$SRC_EXT_DIR/ui/prompt/prompt.css" > "$BUILD_EXT_DIR/prompt_styles.css"
@@ -270,21 +272,6 @@ e2e_lint() {
   fi
 }
 
-e2e_build() {
-  TARGET=$1
-  shift
-  if [ "$TARGET" == "extension" ]; then
-    e2e_build_extension $*;
-  elif [ "$TARGET" == "library" ]; then
-    e2e_build_library $*;
-  elif [ "$TARGET" == "templates" ]; then
-    e2e_build_templates $*;
-  else
-    echo "Invalid build target $TARGET"
-    exit 1
-  fi
-}
-
 RETVAL=0
 
 CMD=$1
@@ -297,20 +284,11 @@ case "$CMD" in
   install_deps)
     e2e_install_deps;
     ;;
-  build)
-    e2e_build $*;
-    ;;
   build_extension)
-    e2e_build_extension;
-    ;;
-  build_extension_debug)
-    e2e_build_extension "debug";
+    e2e_build_extension $1;
     ;;
   build_app)
-    e2e_build_app;
-    ;;
-  build_app_debug)
-    e2e_build_app "debug";
+    e2e_build_app $1;
     ;;
   build_library)
     e2e_build_library;
@@ -331,7 +309,7 @@ case "$CMD" in
     e2e_generate_deps;
     ;;
   *)
-    echo "Usage: $0 {build_extension|build_extension_debug|build_library|build_templates|clean|check_deps|install_deps|testserver|lint}"
+    echo "Usage: $0 {build_app|build_extension|build_library|build_templates|clean|check_deps|install_deps|testserver|lint} [debug]"
     RETVAL=1
 esac
 


### PR DESCRIPTION
Removed some functions that were no longer referenced in the help, extended the help to all targets, and simplified how 'debug' is passed through as an option.