### PR TITLE
Remove redundant echo in ./do.sh

### DIFF
--- a/do.sh
+++ b/do.sh
@@ -138,7 +138,6 @@ e2e_build_extension() {
     jscompile_e2e+=" --js='$var/**.js' --js='!$var/**_test.js'"
   done
   # compile javascript files
-  echo "Compiling JS files..."
   if [ "$1" == "debug" ]; then
     echo "Debug mode enabled"
     jscompile_e2e+=" --debug --formatting=PRETTY_PRINT"


### PR DESCRIPTION
`./do.sh` echos the same thing a few lines later after setting debug flags