### PR TITLE
use a particular release of closure-compiler instead of the latest commit

### DIFF
--- a/download-libs.sh
+++ b/download-libs.sh
@@ -56,7 +56,7 @@ if [ ! -d closure-compiler/.git ]; then
   if [ -d closure-compiler ]; then # remove binary release directory
     rm -rf closure-compiler
   fi
-  git clone --depth 1 https://github.com/google/closure-compiler closure-compiler
+  git clone --branch maven-release-v20150315 --depth 1 https://github.com/google/closure-compiler closure-compiler
 fi
 
 # build closure compiler


### PR DESCRIPTION
closes https://github.com/google/end-to-end/issues/281