### PR TITLE
Using chrome_extensions.js extern file bundled with Closure Compiler instead of downloading it separately.

### DIFF
--- a/compiler.flags
+++ b/compiler.flags
@@ -26,7 +26,7 @@
 --jscomp_error=unknownDefines
 --jscomp_error=uselessCode
 --jscomp_error=visibility
---externs=lib/chrome_extensions.js
+--externs=lib/closure-compiler/contrib/externs/chrome_extensions.js
 --only_closure_dependencies
 --manage_closure_dependencies
 --js lib/closure-library/closure/goog/deps.js

--- a/do.sh
+++ b/do.sh
@@ -41,7 +41,7 @@ e2e_assert_dependencies() {
     lib/zlib.js \
     lib/closure-stylesheets/build/closure-stylesheets.jar \
     lib/closure-compiler/build/compiler.jar \
-    lib/chrome_extensions.js \
+    lib/closure-compiler/contrib/externs/chrome_extensions.js \
   )
   for var in "${files[@]}"
   do

--- a/download-libs.sh
+++ b/download-libs.sh
@@ -82,8 +82,8 @@ if [ ! -d closure-stylesheets ]; then
   cd ..
 fi
 
-if [ ! -f chrome_extensions.js ]; then
-  curl https://raw.githubusercontent.com/google/closure-compiler/master/contrib/externs/chrome_extensions.js -O
+if [ -f chrome_extensions.js ]; then
+  rm -f chrome_extensions.js
 fi
 
 # Temporary fix


### PR DESCRIPTION
Fixes https://github.com/google/end-to-end/issues/287.