### PR TITLE
fallback to file copy if symlink fails.

### DIFF
--- a/download-libs.sh
+++ b/download-libs.sh
@@ -53,7 +53,10 @@ fi
 if [ ! -d zlib.js/.git ]; then
   git clone --depth 1 https://github.com/imaya/zlib.js zlib.js
   mkdir typedarray
-  ln -s ../zlib.js/define/typedarray/use.js typedarray/use.js
+  if ! ln -s ../zlib.js/define/typedarray/use.js typedarray/use.js
+    # symlink failed; strange filesystem? Let's copy...
+    then cp ../zlib.js/define/typedarray/use.js typedarray/use.js
+  fi
 fi
 
 # checkout closure compiler


### PR DESCRIPTION
Fixed #301.

TODO: does `zlib.js` and/or `typedarray` ever get updated?  ...Might need to do that copy again.