### PR TITLE
MIME headers with case-sensitive values 

### DIFF
--- a/src/javascript/crypto/e2e/openpgp/pgpmime/mimenode.js
+++ b/src/javascript/crypto/e2e/openpgp/pgpmime/mimenode.js
@@ -74,6 +74,9 @@ e2e.openpgp.pgpmime.MimeNode = function(options, opt_parent) {
       if (goog.isDefAndNotNull(header.name) &&
           goog.isDefAndNotNull(header.value)) {
         if (goog.isDefAndNotNull(header.params)) {
+          // header.params should only be set if the header value is of type
+          // e2e.openpgp.pgpmime.types.HeaderValueWithParams (i.e., Content-Type
+          // or Content-Disposition headers).
           this.setHeader_(header.name, header.value, header.params);
         } else {
           this.setHeader_(header.name, header.value);
@@ -107,10 +110,17 @@ e2e.openpgp.pgpmime.MimeNode.prototype.addChild = function(options) {
  */
 e2e.openpgp.pgpmime.MimeNode.prototype.setHeader_ = function(key, value,
     opt_params) {
-  var headerValue = e2e.openpgp.pgpmime.Utils.parseHeaderValue(value);
-  if (opt_params) {
-    headerValue.params = headerValue.params || {};
-    goog.object.extend(headerValue.params, opt_params);
+  var titleCaseKey = goog.string.toTitleCase(key, '-').trim();
+  if (titleCaseKey === constants.Mime.CONTENT_TYPE ||
+      titleCaseKey === constants.Mime.CONTENT_DISPOSITION) {
+    var headerValue =
+        e2e.openpgp.pgpmime.Utils.parseHeaderValueWithParams(value);
+    if (opt_params) {
+      headerValue.params = headerValue.params || {};
+      goog.object.extend(headerValue.params, opt_params);
+    }
+  } else {
+    var headerValue = e2e.openpgp.pgpmime.Utils.parseHeaderValueBasic(value);
   }
   goog.object.set(this.header_, key, headerValue);
 };

--- a/src/javascript/crypto/e2e/openpgp/pgpmime/mimenode_test.js
+++ b/src/javascript/crypto/e2e/openpgp/pgpmime/mimenode_test.js
@@ -184,6 +184,22 @@ function testBuildMessage() {
   assertEquals(FINAL_MESSAGE, builtMessage);
 }
 
+
+function testSetHeader() {
+  var setHeaderNode = new e2e.openpgp.pgpmime.MimeNode({
+    multipart: false,
+    optionalHeaders: [
+      {name: constants.Mime.CONTENT_TYPE,
+        value: constants.Mime.MULTIPART_MIXED},
+      {name: constants.Mime.CONTENT_TRANSFER_ENCODING,
+        value: constants.Mime.SEVEN_BIT}]
+  });
+  var expectedHeader = {value: 'text/plain', params: {boundary: '123'}};
+  setHeaderNode.setHeader_('Content-Type', 'text/plain; boundary = 123');
+  assertObjectEquals(expectedHeader, setHeaderNode.header_['Content-Type']);
+}
+
+
 function testIsBoundaryValid() {
   var grandparentNode = new e2e.openpgp.pgpmime.MimeNode({
     multipart: true,

--- a/src/javascript/crypto/e2e/openpgp/pgpmime/pgpmail_test.js
+++ b/src/javascript/crypto/e2e/openpgp/pgpmime/pgpmail_test.js
@@ -161,19 +161,17 @@ function testBuildPGPMimeTree() {
     'Subject: test email', 'From: ystoller@google.com',
     'To: kbsriram@google.com, a@google.com, b@google.com,', ' c@google.com, ' +
         'd@google.com, e@google.com, f@google.com', 'Mime-Version: 1.0', '',
-    'This is an OpenPGP/MIME encrypted message. Please open it from',
-    'the Safe Mail app', '', '----foo',
+    'This is an OpenPGP/MIME encrypted message.', '', '----foo',
     'Content-Type: application/pgp-encrypted; charset="utf-8"; name="',
     ' version.asc"', 'Content-Transfer-Encoding: 7bit',
-    'Content-Description: pgp/mime versions identification', '',
+    'Content-Description: PGP/MIME Versions Identification', '',
     'Version: 1', '----foo',
     'Content-Type: text/plain; charset="utf-8"; ' +
         'name="encrypted.asc"',
     'Content-Transfer-Encoding: 7bit', '', 'some encrypted text',
     '----foo--', ''].join('\r\n');
   var encryptedText = 'some encrypted text';
-  var preamble = 'This is an OpenPGP/MIME encrypted message. ' +
-      'Please open it from the Safe Mail app';
+  var preamble = 'This is an OpenPGP/MIME encrypted message.';
   var mail = new e2e.openpgp.pgpmime.PgpMail({body: encryptedText,
     from: 'ystoller@google.com', to: 'kbsriram@google.com, a@google.com, ' +
         'b@google.com, c@google.com, d@google.com, e@google.com, f@google.com',

--- a/src/javascript/crypto/e2e/openpgp/pgpmime/types.js
+++ b/src/javascript/crypto/e2e/openpgp/pgpmime/types.js
@@ -23,7 +23,8 @@ goog.provide('e2e.openpgp.pgpmime.types.Attachment');
 goog.provide('e2e.openpgp.pgpmime.types.ContentAndHeaders');
 goog.provide('e2e.openpgp.pgpmime.types.Entity');
 goog.provide('e2e.openpgp.pgpmime.types.Header');
-goog.provide('e2e.openpgp.pgpmime.types.HeaderValue');
+goog.provide('e2e.openpgp.pgpmime.types.HeaderValueBasic');
+goog.provide('e2e.openpgp.pgpmime.types.HeaderValueWithParams');
 goog.provide('e2e.openpgp.pgpmime.types.NodeContent');
 
 
@@ -57,15 +58,22 @@ e2e.openpgp.pgpmime.types.Attachment;
 
 
 /**
- * @typedef {Object.<string, !e2e.openpgp.pgpmime.types.HeaderValue>}
+ * @typedef {Object.<string, (!e2e.openpgp.pgpmime.types.HeaderValueBasic|
+ *   !e2e.openpgp.pgpmime.types.HeaderValueWithParams)>}
  */
 e2e.openpgp.pgpmime.types.Header;
 
 
 /**
+ * @typedef {{value: string}}
+ */
+e2e.openpgp.pgpmime.types.HeaderValueBasic;
+
+
+/**
  * @typedef {{value: string, params: (!Object.<string, string>|undefined)}}
  */
-e2e.openpgp.pgpmime.types.HeaderValue;
+e2e.openpgp.pgpmime.types.HeaderValueWithParams;
 
 
 /**

--- a/src/javascript/crypto/e2e/openpgp/pgpmime/utils.js
+++ b/src/javascript/crypto/e2e/openpgp/pgpmime/utils.js
@@ -38,7 +38,7 @@ goog.require('goog.string');
  * @const
  * @private
  */
-var INVALID_MESSAGE_ = 'Invalid MIME format';
+e2e.openpgp.pgpmime.Utils.INVALID_MESSAGE_ = 'Invalid MIME format';
 
 
 /**
@@ -46,7 +46,7 @@ var INVALID_MESSAGE_ = 'Invalid MIME format';
  * @const
  * @private
  */
-var MULTIPART_ = 'multipart/';
+e2e.openpgp.pgpmime.Utils.MULTIPART_ = 'multipart/';
 
 goog.scope(function() {
 var constants = e2e.openpgp.pgpmime.Constants;
@@ -67,15 +67,16 @@ e2e.openpgp.pgpmime.Utils.parseAttachmentEntity = function(node) {
     encoding = encHeader.value;
   }
 
-  // TODO The parseHeaderValueWithParams method is currently not being called
-  // when the Content-Disposition header is parsed. In order to extract the
-  // filename (that is a parameter defined in the header), the method must be
-  // called and possibly altered to support the parsing required by the
-  // Content-Disposition syntax, as defined in RFC 2183.
+  // TODO(ystoller): The parseHeaderValueWithParams method is currently not
+  // being called when the Content-Disposition header is parsed. In order to
+  // extract the filename (that is a parameter defined in the header), the
+  // method must be called and possibly altered to support the parsing required
+  // by the Content-Disposition syntax, as defined in RFC 2183.
   var filename = 'unknown';
 
   if (!goog.isString(node.body)) {
-    var errMsg = INVALID_MESSAGE_ + ' - Attachment invalid';
+    var errMsg = e2e.openpgp.pgpmime.Utils.INVALID_MESSAGE_ +
+        ' - Attachment invalid';
     throw new e2e.openpgp.error.UnsupportedError(errMsg);
   }
   return /** @type {e2e.openpgp.pgpmime.types.Attachment} */ ({filename:
@@ -89,7 +90,7 @@ e2e.openpgp.pgpmime.Utils.parseAttachmentEntity = function(node) {
  * @return {e2e.openpgp.pgpmime.types.HeaderValueBasic}
  */
 e2e.openpgp.pgpmime.Utils.parseHeaderValueBasic = function(text) {
-  return /**@type{e2e.openpgp.pgpmime.types.HeaderValueBasic}*/ (
+  return /** @type {e2e.openpgp.pgpmime.types.HeaderValueBasic} */ (
       {value: text.trim()});
 };
 
@@ -141,7 +142,7 @@ e2e.openpgp.pgpmime.Utils.parseHeaderValueWithParams = function(text) {
     params[paramName] = goog.string.stripQuotes(paramVal, '"');
   });
 
-  return /**@type{e2e.openpgp.pgpmime.types.HeaderValueWithParams}*/ (
+  return /** @type {e2e.openpgp.pgpmime.types.HeaderValueWithParams} */ (
       {value: value, params: params});
 };
 
@@ -202,11 +203,13 @@ e2e.openpgp.pgpmime.Utils.parseHeader_ = function(text) {
       // The Content-Type and Content-Transfer-Encoding headers should only be
       // set once per node. If they appears twice, this most likely indicates an
       // invalidly formatted email.
-      var errMsg = INVALID_MESSAGE_ + ' - duplicate headers';
+      var errMsg = e2e.openpgp.pgpmime.Utils.INVALID_MESSAGE_ +
+          ' - duplicate headers';
       throw new e2e.openpgp.error.UnsupportedError(errMsg);
     }
-    // TODO Allow the code to retain multiple headers (when applicable, e.g.,
-    // for the "Received" header, which often appears multiple times)
+    // TODO(ystoller): Allow the code to retain multiple headers (when
+    // applicable, e.g., for the "Received" header, which often appears multiple
+    // times)
     parsed[name] = value;
   });
 
@@ -265,7 +268,7 @@ e2e.openpgp.pgpmime.Utils.splitNodes_ = function(text, boundary) {
   var startLocation = goog.array.indexOf(lines, '--' + boundary);
   var endLocation = goog.array.indexOf(lines, '--' + boundary + '--');
   if (endLocation === -1 || startLocation === -1) {
-    var errMsg = INVALID_MESSAGE_ +
+    var errMsg = e2e.openpgp.pgpmime.Utils.INVALID_MESSAGE_ +
         ' - cannot find boundary in multipart message';
     throw new e2e.openpgp.error.UnsupportedError(errMsg);
   }
@@ -295,7 +298,8 @@ e2e.openpgp.pgpmime.Utils.parseNode = function(text) {
   // Header must be separated from body by an empty line
   var parts = text.split(separator);
   if (parts.length < 2) {
-    var errMsg = INVALID_MESSAGE_ + ' - no CRLF between headers and body';
+    var errMsg = e2e.openpgp.pgpmime.Utils.INVALID_MESSAGE_ +
+        ' - no CRLF between headers and body';
     throw new e2e.openpgp.error.UnsupportedError(errMsg);
   }
 
@@ -308,7 +312,7 @@ e2e.openpgp.pgpmime.Utils.parseNode = function(text) {
   parsed.header = header;
 
   if (goog.string.caseInsensitiveStartsWith(ctHeader.value.trim(),
-      MULTIPART_) &&
+      e2e.openpgp.pgpmime.Utils.MULTIPART_) &&
       goog.isDefAndNotNull(ctHeader.params) &&
       goog.isDefAndNotNull(ctHeader.params['boundary'])) {
     // This appears to be a multipart message. Split text by boundary.

--- a/src/javascript/crypto/e2e/openpgp/pgpmime/utils.js
+++ b/src/javascript/crypto/e2e/openpgp/pgpmime/utils.js
@@ -29,12 +29,24 @@ goog.require('e2e.openpgp.pgpmime.Text');
 goog.require('e2e.openpgp.pgpmime.types.Entity');
 
 goog.require('goog.array');
-goog.require('goog.asserts');
 goog.require('goog.object');
 goog.require('goog.string');
 
-var invalidMsg = 'Invalid MIME format';
 
+/**
+ * A message that is displayed when invalid MIME messages are encountered.
+ * @const
+ * @private
+ */
+var INVALID_MESSAGE_ = 'Invalid MIME format';
+
+
+/**
+ * The multipart MIME Content-Type.
+ * @const
+ * @private
+ */
+var MULTIPART_ = 'multipart/';
 
 goog.scope(function() {
 var constants = e2e.openpgp.pgpmime.Constants;
@@ -47,7 +59,6 @@ var utils = e2e.openpgp.pgpmime.Utils;
  * @return {e2e.openpgp.pgpmime.types.Attachment}
  */
 e2e.openpgp.pgpmime.Utils.parseAttachmentEntity = function(node) {
-  var filename;
   var encHeader = node.header[constants.Mime.CONTENT_TRANSFER_ENCODING];
   // Implicit content-transfer-encoding is 7bit (RFC 2045).
   var encoding = constants.Mime.SEVEN_BIT;
@@ -56,34 +67,44 @@ e2e.openpgp.pgpmime.Utils.parseAttachmentEntity = function(node) {
     encoding = encHeader.value;
   }
 
-  try {
-    filename = node.header[constants.Mime.CONTENT_DISPOSITION].params.filename;
-  } catch (e) {
-    var errMsg = invalidMsg + ' - Missing filename in attachment';
-    throw new e2e.openpgp.error.UnsupportedError(errMsg);
-  }
+  // TODO The parseHeaderValueWithParams method is currently not being called
+  // when the Content-Disposition header is parsed. In order to extract the
+  // filename (that is a parameter defined in the header), the method must be
+  // called and possibly altered to support the parsing required by the
+  // Content-Disposition syntax, as defined in RFC 2183.
+  var filename = 'unknown';
 
-  if (!filename || !goog.isString(node.body)) {
-    var errMsg = invalidMsg + ' - Attachment invalid';
+  if (!goog.isString(node.body)) {
+    var errMsg = INVALID_MESSAGE_ + ' - Attachment invalid';
     throw new e2e.openpgp.error.UnsupportedError(errMsg);
   }
   return /** @type {e2e.openpgp.pgpmime.types.Attachment} */ ({filename:
-        goog.asserts.assertString(filename), content: node.body,
-        encoding: encoding});
+        filename, content: node.body, encoding: encoding});
 };
 
 
 /**
- * Parses a header value string. Ex: 'multipart/mixed; boundary="foo"'
- * @param {string} text The string to parse
- * @return {e2e.openpgp.pgpmime.types.HeaderValue}
+ * Handles a simple header value string (that doesn't have parameters).
+ * @param {string} text The header value.
+ * @return {e2e.openpgp.pgpmime.types.HeaderValueBasic}
  */
-e2e.openpgp.pgpmime.Utils.parseHeaderValue = function(text) {
+e2e.openpgp.pgpmime.Utils.parseHeaderValueBasic = function(text) {
+  return /**@type{e2e.openpgp.pgpmime.types.HeaderValueBasic}*/ (
+      {value: text.trim()});
+};
+
+
+/**
+ * Parses a header value string that might contain parameters.
+ * Ex: 'multipart/mixed; boundary="foo"'
+ * @param {string} text The string to parse
+ * @return {e2e.openpgp.pgpmime.types.HeaderValueWithParams}
+ */
+e2e.openpgp.pgpmime.Utils.parseHeaderValueWithParams = function(text) {
   var parts = text.split(';');
   var firstPart = parts.shift();
 
-  // Normalize value to lowercase since it's case insensitive
-  var value = goog.string.stripQuotes(firstPart.toLowerCase().trim(), '"');
+  var value = goog.string.stripQuotes(firstPart.trim(), '"');
 
   var params = {};
   goog.array.forEach(parts, function(part) {
@@ -120,7 +141,7 @@ e2e.openpgp.pgpmime.Utils.parseHeaderValue = function(text) {
     params[paramName] = goog.string.stripQuotes(paramVal, '"');
   });
 
-  return /**@type{e2e.openpgp.pgpmime.types.HeaderValue}*/ (
+  return /**@type{e2e.openpgp.pgpmime.types.HeaderValueWithParams}*/ (
       {value: value, params: params});
 };
 
@@ -166,10 +187,14 @@ e2e.openpgp.pgpmime.Utils.parseHeader_ = function(text) {
       return;
     }
 
-    // Header names are not case sensitive. Normalize to TitleCase.
+    // Normalizing to TitleCase (this is only used for searching).
     var name = goog.string.toTitleCase(parts.shift(), '-').trim();
-    var value = /** @type {e2e.openpgp.pgpmime.types.HeaderValue} */
-        (utils.parseHeaderValue(parts.join(':')));
+
+    if (name === constants.Mime.CONTENT_TYPE) {
+      var value = utils.parseHeaderValueWithParams(parts.join(':'));
+    } else {
+      var value = utils.parseHeaderValueBasic(parts.join(':'));
+    }
 
     if (goog.isDefAndNotNull(parsed[name]) && (name ===
         constants.Mime.CONTENT_TYPE || name ===
@@ -177,9 +202,11 @@ e2e.openpgp.pgpmime.Utils.parseHeader_ = function(text) {
       // The Content-Type and Content-Transfer-Encoding headers should only be
       // set once per node. If they appears twice, this most likely indicates an
       // invalidly formatted email.
-      var errMsg = invalidMsg + ' - duplicate headers';
+      var errMsg = INVALID_MESSAGE_ + ' - duplicate headers';
       throw new e2e.openpgp.error.UnsupportedError(errMsg);
     }
+    // TODO Allow the code to retain multiple headers (when applicable, e.g.,
+    // for the "Received" header, which often appears multiple times)
     parsed[name] = value;
   });
 
@@ -192,7 +219,6 @@ e2e.openpgp.pgpmime.Utils.parseHeader_ = function(text) {
   goog.object.setIfUndefined(parsed, constants.Mime.CONTENT_TRANSFER_ENCODING, {
     value: constants.Mime.SEVEN_BIT
   });
-
   return parsed;
 };
 
@@ -239,7 +265,8 @@ e2e.openpgp.pgpmime.Utils.splitNodes_ = function(text, boundary) {
   var startLocation = goog.array.indexOf(lines, '--' + boundary);
   var endLocation = goog.array.indexOf(lines, '--' + boundary + '--');
   if (endLocation === -1 || startLocation === -1) {
-    var errMsg = invalidMsg + ' - cannot find boundary in multipart message';
+    var errMsg = INVALID_MESSAGE_ +
+        ' - cannot find boundary in multipart message';
     throw new e2e.openpgp.error.UnsupportedError(errMsg);
   }
   // Ignore the epilogue after the end boundary inclusive.
@@ -268,19 +295,21 @@ e2e.openpgp.pgpmime.Utils.parseNode = function(text) {
   // Header must be separated from body by an empty line
   var parts = text.split(separator);
   if (parts.length < 2) {
-    var errMsg = invalidMsg + ' - no CRLF between headers and body';
+    var errMsg = INVALID_MESSAGE_ + ' - no CRLF between headers and body';
     throw new e2e.openpgp.error.UnsupportedError(errMsg);
   }
 
   var header = utils.parseHeader_(parts.shift());
   var body = parts.join(constants.Mime.CRLF + constants.Mime.CRLF);
 
-  var ctHeader = /** @type {e2e.openpgp.pgpmime.types.HeaderValue} */
+  var ctHeader = /** @type {e2e.openpgp.pgpmime.types.HeaderValueWithParams} */
       (header[constants.Mime.CONTENT_TYPE]);
   var parsed = {};
   parsed.header = header;
 
-  if (goog.isDefAndNotNull(ctHeader.params) &&
+  if (goog.string.caseInsensitiveStartsWith(ctHeader.value.trim(),
+      MULTIPART_) &&
+      goog.isDefAndNotNull(ctHeader.params) &&
       goog.isDefAndNotNull(ctHeader.params['boundary'])) {
     // This appears to be a multipart message. Split text by boundary.
     var nodes = utils.splitNodes_(body, ctHeader.params['boundary']);

--- a/src/javascript/crypto/e2e/openpgp/pgpmime/utils_test.js
+++ b/src/javascript/crypto/e2e/openpgp/pgpmime/utils_test.js
@@ -61,7 +61,7 @@ var PLAINTEXT_MESSAGE = ['From: Nathaniel Borenstein <nsb@bellcore.com>',
   '',
   'aGVsbG8gd29ybGQK',
   '--simple boundary--',
-  'This is the epilogue.  It is also to be ignored.'].join('\n');
+  'This is the epilogue.  It is also to be ignored.'].join('\r\n');
 
 var PLAINTEXT_BODY = ['This is implicitly typed plain ASCII text.',
   '',
@@ -71,6 +71,60 @@ var PLAINTEXT_BODY = ['This is implicitly typed plain ASCII text.',
   'It DOES end with a linebreak.',
   '',
   ''].join('\r\n');
+
+var TEST_EMAIL = ['Delivered-To: ystoller@google.com',
+  'Received: by 10.31.190.6 with SMTP id o6csp207937vkf;',
+  '        Wed, 29 Jul 2015 17:23:28 -0700 (PDT)',
+  'X-Received: by 10.107.10.96 with SMTP id u93mr6392667ioi.172.1438215808478;',
+  '        Wed, 29 Jul 2015 17:23:28 -0700 (PDT)',
+  'Return-Path: <dang.hvu@gmail.com>',
+  'Received: from mail-io0-x22c.google.com (mail-io0-x22c.google.com. ' +
+      '[2607:f8b0:4001:c06::22c])',
+  '        by mx.google.com with ESMTPS id e5si18657igz.54.2015.07.29.17.23.28',
+  '        for <ystoller@google.com>',
+  '        (version=TLSv1.2 cipher=ECDHE-RSA-AES128-GCM-SHA256 bits=128/128);',
+  '        Wed, 29 Jul 2015 17:23:28 -0700 (PDT)',
+  'Received-SPF: pass (google.com: domain of dang.hvu@gmail.com designates ' +
+      '2607:f8b0:4001:c06::22c as permitted sender) ' +
+      'client-ip=2607:f8b0:4001:c06::22c;',
+  'Authentication-Results: mx.google.com;',
+  '       spf=pass (google.com: domain of dang.hvu@gmail.com designates ' +
+      '2607:f8b0:4001:c06::22c as permitted sender) ' +
+      'smtp.mail=dang.hvu@gmail.com;',
+  '       dkim=pass header.i=@gmail.com;',
+  '       dmarc=pass (p=NONE dis=NONE) header.from=gmail.com',
+  'Received: by mail-io0-x22c.google.com with SMTP id g141so38367292ioe.3',
+  '        for <ystoller@google.com>; Wed, 29 Jul 2015 17:23:28 -0700 (PDT)',
+  'DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;',
+  '        d=gmail.com; s=20120113;',
+  '        h=mime-version:date:message-id:subject:from:to:content-type;',
+  '        bh=qudyov98wfFdQ2xQUP+0LzZKrz32kEkMCxiQBXyGjaQ=;',
+  '        b=aEKwmc7f22TrGJ3jldEZ/y3uSZYdRGm1ZKB2fw0y9JlcUivXxv+6DdMwABK' +
+      'blpSR4D',
+  '         7Ol97uGcDc7lyGvMO6Kr3twp4N9nqcP1auk1KsDsRyW55L1ZCntlW05x+wUd' +
+      'AtwjOUCF',
+  '         x6slpIlvPHfe+9ldAxqyPjMaOx0s2IvxCUDPfe7h/C/Jixc+eNq8S3YO+0xL' +
+      '9F2mbHnO',
+  '         gHUc01nlIesDEcs3xyzwRaPk9NMpFqwVXdrPzHoAg9CmUNw3fmEVGAj1p96R' +
+      'IyG/V39H',
+  '         7xQaM69nGMKIH5xVoucbNj/zGL0G7Phn3DYInIBfBZu2iN86TyacJluB9jU2' +
+      'E40PNImq',
+  '         j2Rg==', 'MIME-Version: 1.0',
+  'X-Received: by 10.107.135.200 with SMTP id ' +
+      'r69mr6031368ioi.54.1438215808067;',
+  ' Wed, 29 Jul 2015 17:23:28 -0700 (PDT)',
+  'Received: by 10.79.93.2 with HTTP; Wed, 29 Jul 2015 17:23:27 -0700 (PDT)',
+  'Received: by 10.79.93.2 with HTTP; Wed, 29 Jul 2015 17:23:27 -0700 (PDT)',
+  'Date: Wed, 29 Jul 2015 17:23:27 -0700', 'Message-ID: ' +
+      '<CAGrabN7TM2dr1+qF2pCanga6w583QoNPBz1TS27irr5b25D5Kg@mail.gmail.com>',
+  'Subject: Hello yoni', 'From: Hoang-Vu Dang <dang.hvu@gmail.com>',
+  'To: Jonathan Stoller <ystoller@google.com>',
+  'Content-Type: multipart/alternative; boundary=001a113eb0c259b018051c0cb660',
+  '', '--001a113eb0c259b018051c0cb660',
+  'Content-Type: text/plain; charset=UTF-8', '', 'Wohoo', '',
+  '--001a113eb0c259b018051c0cb660', 'Content-Type: text/html; charset=UTF-8',
+  '', '<p dir="ltr">Wohoo</p>', '',
+  '--001a113eb0c259b018051c0cb660--'].join('\r\n');
 
 
 function setUp() {
@@ -91,12 +145,12 @@ function testGetMultipartMailContent() {
 
 
 function testParseAttachmentEntity() {
-  var rawAttachment = {'body': 'hello world\n', 'header':
+  var rawAttachment = {'body': 'hello world\r\n', 'header':
         {'Content-Disposition': {'params': {'filename': 'foo.txt'}, 'value':
                 'attachment'}, 'Content-Transfer-Encoding': {'params': {},
             'value': 'base64'}, 'Content-Type': {'params': {}, 'value':
                 'application/octet-stream'}}};
-  var parsedAttachment = {filename: 'foo.txt', content: 'hello world\n',
+  var parsedAttachment = {filename: 'unknown', content: 'hello world\r\n',
     'encoding': 'base64'};
   assertObjectEquals(parsedAttachment, utils.parseAttachmentEntity(
       rawAttachment));
@@ -114,37 +168,95 @@ function testGetSinglePartMailContent() {
 }
 
 
-function testParseHeaderValue() {
+function testHeaderValueCasesArePreserved() {
+  // The cases of header values should not be altered.
+  var header = 'Message-ID: aBcDe';
+  assertEquals('aBcDe', utils.parseHeader_(header)['Message-ID'].value);
+}
+
+function testHeaderParameterNamesAreLowerCased() {
+  // Parameter names are case-insensitive and should be normalized to lower-case
+  var header = 'Content-Type: multipart/mixed; BOUNDARY= 123';
+  assertEquals(true, utils.parseHeader_(
+      header)['Content-Type'].params.hasOwnProperty('boundary'));
+}
+
+function testMessageWithMultipleHeaders() {
+  // Messages with multiple content-type or content-transfer-encoding headers
+  // should fail.
+  var multipleContentType = ['Content-Type: text/plain',
+    'Content-Type: text/plain', 'Content-Transfer-Encoding: 7bit', '',
+    'Hello'].join('\r\n');
+  assertThrows('Message with multiple content types headers' +
+      'should raise exception', function() {
+        utils.parseNode(multipleContentType);
+      });
+  var multipleContentTransferEncoding = ['Content-Type: text/plain',
+    'Content-Transfer-Encoding: 7bit', 'Content-Transfer-Encoding: 7bit', '',
+    'Hello'].join('\r\n');
+  assertThrows('Message with multiple content transfer encoding headers' +
+      'should raise exception', function() {
+        utils.parseNode(multipleContentTransferEncoding);
+      });
+
+  // Other headers that appear multiple times should parse successfully.
+  var multipleRandomHeader = ['Content-Type: text/plain',
+    'Content-Transfer-Encoding: 7bit', 'Received: yesterday',
+    'Received: yesterday', '', 'Hello'].join('\r\n');
+  assertEquals('Hello', utils.parseNode(multipleRandomHeader).body);
+}
+
+function testParseHeaderValueWithParams() {
   // Attribute names that include characters that aren't visible ASCII
   // should not be returned (whitespace is also invalid).
   // In this case, there is a tab metacharacter in an attribute name
   var attributeNonVisibleAsciiFails =
-      'MULTIPART/mixed;   BO\tUNDARY= "foo="; bar=somevalue';
+      'multipart/mixed;   bo\tundary= "foo="; bar=somevalue';
   assertObjectEquals({value: 'multipart/mixed', params: {bar: 'somevalue'}},
-      utils.parseHeaderValue(attributeNonVisibleAsciiFails));
+      utils.parseHeaderValueWithParams(attributeNonVisibleAsciiFails));
 
   // Attribute values that include characters that aren't visible ASCII
   // should not be returned (whitespace is also invalid).
   // In this case, there is a whitespace in an attribute value
   var attributeNonVisibleAsciiFails =
-      'MULTIPART/mixed;   BOUNDARY= fo o; bar=somevalue';
+      'multipart/mixed;   boundary= fo o; bar=somevalue';
   assertObjectEquals({value: 'multipart/mixed', params: {bar: 'somevalue'}},
-      utils.parseHeaderValue(attributeNonVisibleAsciiFails));
+      utils.parseHeaderValueWithParams(attributeNonVisibleAsciiFails));
 
   // Attribute values that contain a special character (here, an equals sign)
   // that isn't enclosed in quotes should not be returned
   // In this case, an attribute value has an equals sign that isn't enclosed
   // in quotes.
   var equalSignWithoutQuotes =
-      'MULTIPART/mixed;   BOUNDARY= foo=; bar=somevalue';
+      'multipart/mixed;   boundary= foo=; bar=somevalue';
   assertObjectEquals({value: 'multipart/mixed', params: {bar: 'somevalue'}},
-      utils.parseHeaderValue(equalSignWithoutQuotes));
+      utils.parseHeaderValueWithParams(equalSignWithoutQuotes));
 
   // This is a valid header value - it should be parsed and returned in full.
-  var text = 'MULTIPART/mixed;   BOUNDARY=" f oo=";  bar=somevalue';
-  assertObjectEquals({value: 'multipart/mixed', params: { boundary: ' f oo=',
+  var text = 'multipart/mixed;   boundary=" f oo=";  bar=somevalue';
+  assertObjectEquals({value: 'multipart/mixed', params: {boundary: ' f oo=',
     bar: 'somevalue'
-  }}, utils.parseHeaderValue(text));
+  }}, utils.parseHeaderValueWithParams(text));
+}
+
+
+function testParseHeaderValueBasic() {
+  // parseHeaderValueBasic should return an object of type
+  // e2e.openpgp.pgpmime.types.HeaderValueBasic, without lowering the case.
+  var text = 'abcDE';
+  var expectedObj = {value: text};
+  assertObjectEquals(expectedObj, utils.parseHeaderValueBasic(text));
+
+  // Verifies that quotes are not removed
+  text = '"Laser"';
+  expectedObj = {value: text};
+  assertObjectEquals(expectedObj, utils.parseHeaderValueBasic(text));
+
+  // Verifies that semi-colons in the middle of a non-parameter header parse
+  // successfully
+  text = '"Things to purchase for hike: Water; trail mix; miscellaneous..."';
+  expectedObj = {value: text};
+  assertObjectEquals(expectedObj, utils.parseHeaderValueBasic(text));
 }
 
 
@@ -200,3 +312,45 @@ function testLineSeparator() {
   assertEquals('content of message', utils.parseNode(message).body);
 }
 
+function testVerifyMultipart() {
+  // Verifies that messages will only be treated as multipart if they have both
+  // a valid content-type (i.e., type 'multipart'), and a boundary.
+  var message = ['Content-Type: multiPArt/mixed; boundary=123', '', '--123',
+    'Content-Type: plain/text', '', 'part1', '--123',
+    'Content-Type: plain/text', '', 'part2', '--123--'].join('\r\n');
+  var expectedResult = ['part1\r\n', 'part2'];
+  var result = utils.parseNode(message);
+  assertEquals(2, result.body.length);
+  assertObjectEquals(expectedResult[0], result.body[0].body);
+  assertObjectEquals(expectedResult[1], result.body[1].body);
+
+  // The following message does not have a valid content type, so the entire
+  // content of the message following the initial headers should be parsed as
+  // a single node.
+  message = ['Content-Type: multipa/mixed; boundary=123', '', '--123',
+    'Content-Type: plain/text', '', 'part1', '--123',
+    'Content-Type: plain/text', '', 'part2', '--123--'].join('\r\n');
+  var expectedResult = ['--123', 'Content-Type: plain/text', '', 'part1',
+    '--123', 'Content-Type: plain/text', '', 'part2', '--123--'].join('\r\n');
+  result = utils.parseNode(message);
+  assertEquals(expectedResult, result.body);
+
+  // The following message does not have a boundary.
+  var message = ['Content-Type: multiPArt/mixed', '', '--123',
+    'Content-Type: plain/text', '', 'part1', '--123',
+    'Content-Type: plain/text', '', 'part2', '--123--'].join('\r\n');
+  result = utils.parseNode(message);
+  assertEquals(expectedResult, result.body);
+}
+
+function testTypicalEmail() {
+  // Verifies that an typical email that comes with many (potentially) unused
+  // and unrecognized headers parses correctly.
+  var expectedObj = [{body: 'Wohoo\r\n\r\n'},
+        {body: '<p dir="ltr">Wohoo</p>\r\n'}];
+  var parsedEmail = utils.parseNode(TEST_EMAIL);
+  assertObjectEquals(expectedObj[0].body,
+      utils.parseNode(TEST_EMAIL).body[0].body);
+  assertObjectEquals(expectedObj[1].body,
+      utils.parseNode(TEST_EMAIL).body[1].body);
+}


### PR DESCRIPTION
Many MIME headers have case-sensitive values  (email subjects, message IDs, etc). The MIME library now preserves the original header values, without changing their case.
Additionally, we only support the extraction of parameters for the Content-Type header.
The Content-Disposition header's parameters are not extracted (preventing us from knowing, among other things, the filename of an attachment).