### PR TITLE
Fixes the download-libs.sh script

### DIFF
--- a/download-libs.sh
+++ b/download-libs.sh
@@ -37,10 +37,11 @@ fi
 if [ ! -d lib ]; then
   mkdir lib
 fi
-cd lib
 
 git submodule init
 git submodule update
+
+cd lib
 
 # symlink typedarray
 if [ ! -d typedarray ]; then


### PR DESCRIPTION
Currently the script fails as it tries to initialise the submodules from a subdirectory.

This changes ensure that it first pulls all the submodules and then changes into the `lib` direcory.