### PR TITLE
Update .travis.yml to pull closure-linter from its new GitHub repo.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 install:
-  - sudo pip install svn+https://closure-linter.googlecode.com/svn/trunk#egg=gjslint
+  - sudo pip install git+https://github.com/google/closure-linter.git
   - ./do.sh install_deps
 
 script:


### PR DESCRIPTION
Google Code is shutting down soon.