### PR TITLE
Fixed error propagation in action executors

### DIFF
--- a/src/javascript/crypto/e2e/extension/api/api.js
+++ b/src/javascript/crypto/e2e/extension/api/api.js
@@ -162,7 +162,8 @@ api.Api.prototype.executeAction_ = function(callback, req) {
     outgoing.content = resp;
     callback(outgoing);
   }, function(error) {
-    outgoing.error = chrome.i18n.getMessage(error.messageId);
+    outgoing.error = goog.isDef(error.messageId) ?
+        chrome.i18n.getMessage(error.messageId) : error.message;
     callback(outgoing);
   });
 };


### PR DESCRIPTION
For those error messages without an messageId, the error will be empty, as in 
https://github.com/google/end-to-end/pull/351/files#diff-2f502f54b21e66245edaad1fd9ed05e1L165

An example error thrown at https://github.com/google/end-to-end/blob/master/src/javascript/crypto/e2e/openpgp/block/encryptedmessage.js#L202:
`throw new e2e.openpgp.error.DecryptError('No keys found for message.');` will result in `outgoing.error = ''`
 
The way it is fixed is similar to other use cases:
https://github.com/google/end-to-end/search?utf8=%E2%9C%93&q=messageId