### PR TITLE
enhanced ASCII armor message parsing

### DIFF
--- a/src/javascript/crypto/e2e/openpgp/asciiarmor_test.html
+++ b/src/javascript/crypto/e2e/openpgp/asciiarmor_test.html
@@ -172,9 +172,29 @@
     assertEquals('hello world new', parsed.getBody());
     assertEquals('SHA1', parsed.getSignature().hashAlgorithm);
     console.log(e2e.openpgp.asciiArmor.encodeClearSign(parsed));
+
+    // Signed by user: "test 4" 1024-bit RSA key, ID 092DA808
+    var clearSignTrailingSpace =
+      '-----BEGIN PGP SIGNED MESSAGE----- \r\n' +
+      'Hash: SHA1 \r\n' +
+      ' \r\n' +
+      'hello world new \r\n' +
+      '-----BEGIN PGP SIGNATURE----- \r\n' +
+      'Version: GnuPG v1.4.11 (GNU/Linux) \r\n' +
+      ' \r\n' +
+      'iJwEAQECAAYFAlIny1sACgkQBv+crAktqAgPqgP/bG1lJAyVBa99rJTLn9RAJsC0 \r\n' +
+      '2d7hJBdEiwmakEzbGfWG48RM7mq4X+W3j36D8qeCWpYkJk+zd4g25TJ7DIwoBfCv \r\n' +
+      'J8S0vVfQ6FYTNHLuAggXs7ooLfovq2fP6iuVjwNX57JDxllHmS8tPAbIgIs+VRag \r\n' +
+      'hOia0yJgN0DoFSylakY= \r\n' +
+      '=qRFP \r\n' +
+      '-----END PGP SIGNATURE----- ';
+    parsed = e2e.openpgp.asciiArmor.parseClearSign(clearSignTrailingSpace);
+    assertEquals('hello world new', parsed.getBody());
+    assertEquals('SHA1', parsed.getSignature().hashAlgorithm);
+
     var invalid =
       '-----BEGIN PGP SIGNED MESSAGE-----\n' +
-      'Hash: SHA1\n \ntampered message.\n' +
+      // 'Hash: SHA1\n' + // missing hash algorithm
       '\n' +
       'hello world new\n' +
       '-----BEGIN PGP SIGNATURE-----\n' +


### PR DESCRIPTION
The ASCII armor parsing algorithm of clearsign message is enhanced, so it's more lenient to support some clients that inject a space per line. The tolerance to a whitespace before newline char is already implemented in parsing encrypted message, as in https://github.com/google/end-to-end/pull/354/files#diff-b72f224b22d6c1be65e18c38601aeec4R134

c.c. @neraliu, this fixed the invalid clear sign issue