### PR TITLE
enable bzip2 and add test for bzip2 decompression.

### DIFF
--- a/src/javascript/crypto/e2e/compression/all.js
+++ b/src/javascript/crypto/e2e/compression/all.js
@@ -22,6 +22,8 @@
 goog.provide('e2e.compression.all');
 
 /** @suppress {extraRequire} intentional import */
+goog.require('e2e.compression.Bzip2');
+/** @suppress {extraRequire} intentional import */
 goog.require('e2e.compression.Zip');
 /** @suppress {extraRequire} intentional import */
 goog.require('e2e.compression.Zlib');

--- a/src/javascript/crypto/e2e/compression/bzip2.js
+++ b/src/javascript/crypto/e2e/compression/bzip2.js
@@ -29,6 +29,7 @@ goog.require('e2e.async.Result');
 goog.require('e2e.compression.Algorithm');
 goog.require('e2e.compression.Compression');
 goog.require('e2e.compression.Error');
+goog.require('e2e.compression.factory');
 
 goog.require('goog.array');
 
@@ -504,6 +505,5 @@ e2e.compression.Bzip2.Bits_.prototype.read = function(bits) {
   return result;
 };
 
-// TODO(adhintz) Uncomment after bzip2 is implemented.
-// e2e.compression.factory.add(e2e.compression.Bzip2,
-//    e2e.compression.Algorithm.BZIP2);
+e2e.compression.factory.add(e2e.compression.Bzip2,
+    e2e.compression.Algorithm.BZIP2);

--- a/src/javascript/crypto/e2e/openpgp/contextimpl_test.html
+++ b/src/javascript/crypto/e2e/openpgp/contextimpl_test.html
@@ -366,6 +366,32 @@ eGC9JuVC0VK58w==
 -----END PGP PUBLIC KEY BLOCK-----
 </textarea>
 
+<!--
+echo "hello bz2 world" > file.txt
+gpg --armor --compress-algo bzip2 -c file.txt
+
+:symkey enc packet: version 4, cipher 3, s2k 3, hash 2
+  salt 1dea6a58eb6dfdea, count 65536 (96)
+gpg: CAST5 encrypted data
+:encrypted data packet:
+  length: 94
+gpg: encrypted with 1 passphrase
+:compressed packet: algo=3
+:literal data packet:
+  mode b (62), created 1452906719, name="file.txt",
+  raw data: 16 bytes
+-->
+<textarea id="symmetricKeyBzip2">
+-----BEGIN PGP MESSAGE-----
+Version: GnuPG v1
+
+jA0EAwMCHepqWOtt/epgyV5U5XfyScWgyppsiIm45xEgw8PKjwnjDUTZ1RsBWh5X
+1jBLLMnZ+KV2iATxoChh+/jJFqe02caByMpF/A4CkWS2s5ZFEasuPrG99IYIw9Ji
+hwTUHoOwXZYN6egvFLlN
+=rPTG
+-----END PGP MESSAGE-----
+</textarea>
+
 <script>
 var asyncTestCase = goog.testing.AsyncTestCase.createAndInstall(document.title);
 asyncTestCase.stepTimeout = 10000;
@@ -599,6 +625,19 @@ function testClearSign() {
     assertEquals(1, result.verify.success.length);
     asyncTestCase.continueTesting();
   }, fail);
+}
+
+function testDecryptSymmetricBzip2() {
+  var encrypted = document.getElementById('symmetricKeyBzip2').value;
+  var plaintext = 'hello bz2 world\n';
+  asyncTestCase.waitForAsync('waiting for decryption.');
+  context.verifyDecrypt(passphraseCallback, encrypted).addCallback(function(result) {
+    var data = result['decrypt']['data'];
+    assertEquals(plaintext, e2e.byteArrayToString(data));
+    asyncTestCase.continueTesting();
+  }).addErrback(function(error) {
+    throw error;
+  });
 }
 
 function testEncryptSymmetric() {


### PR DESCRIPTION
Note that we can only decompress bzip2, not compress to bzip2. I didn't
see any places in the current code where this would cause an issue, but
it's a bit awkward. Can you think of any issues or how we should deal
with this differently?

Although our bzip2 implementation does not have CRC checking, that's
probably fine as openpgp has integrity protection in other places.

closes #182