### PR TITLE
Fix bug in e2e bzip2 decompressing where loop counter was incorrectly

### DIFF
--- a/src/javascript/crypto/e2e/compression/bzip2.js
+++ b/src/javascript/crypto/e2e/compression/bzip2.js
@@ -71,6 +71,9 @@ e2e.compression.Bzip2.prototype.decompress = function(compressedData) {
   var crc = bits.read(32);  // crc for whole stream.
   // TODO(adhintz) Verify checksum for whole stream.
 
+  // TODO(adhintz) Read concatenated bzip2 streams, such as at
+  // https://github.com/kjn/lbzip2/blob/master/tests/concat.bz2
+
   var data = goog.array.flatten(results);
   return e2e.async.Result.toResult(data);
 };
@@ -277,7 +280,6 @@ e2e.compression.Bzip2.prototype.readBlock_ = function(bits) {
     tPos >>>= 8;
 
     if (byteRepeats == 3) {  // Hit the 4 equal bytes, so repeating time.
-      i++;
       for (var j = 0; j < b; j++) {
         finalData.push(lastByte);
       }

--- a/src/javascript/crypto/e2e/compression/bzip2_test.html
+++ b/src/javascript/crypto/e2e/compression/bzip2_test.html
@@ -73,6 +73,23 @@ function testDecompress() {
   assertArrayEquals([0x68, 0x69, 0x0a], decompressedData);
 }
 
+function testRepeating() {
+  var compressedData = [  // Compressed literal data packet created by gpg.
+    66, 90, 104, 54, 49, 65, 89, 38, 83, 89, 115, 157, 156, 228, 0, 0, 15, 127, 144, 8, 144, 16, 0,
+    0, 0, 132, 0, 32, 0, 1, 16, 62, 161, 212, 128, 8, 4, 32, 0, 34, 128, 0, 0, 242, 133, 6, 141, 26,
+    12, 128, 210, 114, 100, 65, 90, 115, 119, 166, 121, 183, 43, 223, 120, 1, 34, 65, 63, 23, 114,
+    69, 56, 80, 144, 115, 157, 156, 228
+    ];
+  var algo = new e2e.compression.Bzip2();
+  var decompressedData = e2e.async.Result.getValue(algo.decompress(compressedData));
+  assertArrayEquals([
+    172, 52, 98, 3, 100, 111, 99, 86, 163, 47, 119, 114, 101, 112, 101, 97, 116, 105, 110, 103, 65,
+    65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 90, 90, 90,
+    90, 90, 90, 90, 90, 90, 90, 90, 10
+  ],
+                    decompressedData);
+}
+
 function testZeros() {
   var compressedData = [  // 32 0s compressed with bzip2, from golang test.
     0x42, 0x5a, 0x68, 0x39, 0x31, 0x41, 0x59, 0x26, 0x53, 0x59, 0xb5, 0xaa, 0x50, 0x98, 0x00, 0x00,


### PR DESCRIPTION
being incremented when processing repeating bytes.

Fixes issue #364