### PR TITLE
Fixing the java.lang.OutOfMemoryError Error that happens on some build envs, re: #367

### DIFF
--- a/do.sh
+++ b/do.sh
@@ -213,7 +213,7 @@ e2e_build_extension() {
   e2e_build_closure_lib_ "e2e.ext.ui.settings.bootstrap" "$BUILD_EXT_DIR/settings_binary.js" "$BUILD_TPL_DIR" "$1"
   e2e_build_closure_lib_ "e2e.ext.ui.welcome.bootstrap" "$BUILD_EXT_DIR/welcome_binary.js" "$BUILD_TPL_DIR" "$1"
   # compile css files
-  csscompile_e2e="java -jar lib/closure-stylesheets/build/closure-stylesheets.jar src/javascript/crypto/e2e/extension/ui/styles/base.css"
+  csscompile_e2e="java -jar -Xms512m -Xmx1024m lib/closure-stylesheets/build/closure-stylesheets.jar src/javascript/crypto/e2e/extension/ui/styles/base.css"
   echo "Compiling CSS files..."
   $csscompile_e2e "$SRC_EXT_DIR/ui/glass/glass.css" > "$BUILD_EXT_DIR/glass_styles.css"
   $csscompile_e2e "$SRC_EXT_DIR/ui/prompt/prompt.css" > "$BUILD_EXT_DIR/prompt_styles.css"

--- a/do.sh
+++ b/do.sh
@@ -18,7 +18,7 @@
 #  * @author koto@google.com (Krzysztof Kotowicz)
 #  */
 PYTHON_CMD="python"
-JSCOMPILE_CMD="java -jar lib/closure-compiler/build/compiler.jar --flagfile=compiler.flags"
+JSCOMPILE_CMD="java -jar -Xms512m -Xmx1024m lib/closure-compiler/build/compiler.jar --flagfile=compiler.flags"
 CKSUM_CMD="cksum" # chosen because it's available on most Linux/OS X installations
 NODEJS_CMD="${NODEJS_CMD:-nodejs}"
 BUILD_DIR="build"


### PR DESCRIPTION
This is re: #367 . I ran into this on a VM, saw there was no PR yet, and made the change.

Although @koto  suggested putting @valo 's change (`export _JAVA_OPTIONS="-Xms512m -Xmx1024m"`) directly into do.sh, I did it in a way that will not clobber an existing `_JAVA_OPTIONS` env var that a user may already have set for other builds in their system.

If there is anything I missed or any issues, please let me know and I will fix them for the PR. I also would suggest probably making it more modular than this, unless these are the bare minimums for compilation which would be fine too.